### PR TITLE
Fix #378 (infra) - Support Sonar CSV and sysinfo data in infiltrate

### DIFF
--- a/code/exfiltrate/README.md
+++ b/code/exfiltrate/README.md
@@ -8,18 +8,10 @@ See comment block at the beginning of exfiltrate.go for all information.
 
 ## Future developments
 
-In the future, I expect we'll want to do at least some other source formats:
+None expected.  This is basically a tiny subset of `curl` plus a random-wait feature.  It may be
+replaced by a shell script, or by an mqtt client if we switch from http to mqtt.
 
-"sysinfo/json"
-   The sysinfo program figures out the machine configuration and prints a json package with the
-   data
+## Past sins
 
-"diskstatus/json"
-  The diskstatus program prints the fullness of disks
+This used to be a lot more complicated, but the complications did not pay off.
 
-"slurm-seff/json"
-  Slurm data from "seff"
-
-In the future, at least some type of binary format is expected for the output.
-
-In the future, other protocols (mqtt?) are expected for the target

--- a/code/exfiltrate/exfiltrate.go
+++ b/code/exfiltrate/exfiltrate.go
@@ -1,62 +1,77 @@
-// `exfiltrate` - data forwarder for Sonar data, to run on HPC nodes.
+// `exfiltrate` - data forwarder for all sorts of data, to run on HPC nodes.
 //
-// Exfiltrate receives data on stdin, parses it, reformats it for transmission, and forwards it to a
-// network agent.  It attempts to do so reliably: if forwarding fails with some recoverable error it
-// will retry the sending later.  It will batch outputs when possible.  It will randomly pick a
-// sending time in a specified sending window, in order to offload the server without impacting the
-// quality or timing of measurement data.  Input formats, transmission formats, and agent addresses
-// are controlled by options.
+// Exfiltrate receives data on stdin and forwards it to a network service, with some features:
 //
-// Run with -h for help.
+// - Input is obtained first: Exfiltrate reads all its input before trying to send, so the
+//   originator of the data will be allowed to exit before exfiltrate is finished.
+// - Forwarding is reliable: if forwarding fails with some recoverable error, exfiltrate will
+//   retry the sending later.
+// - Sending is randomized: Exfiltrate will randomly pick a sending time in a specified sending
+//   window, in order to distribute load on the server without impacting the quality or timing of
+//   measurement data.
 //
-// The arguments -cluster, -output, -source, -target, and -window are all mandatory.  -cluster is
-// used to name the cluster from which the data comes, if that information is not part of the data
-// (a weakness of the current Sonar data).
+// In truth, though, this is just `( sleep( ((RANDOM % $window)) ); curl --data-binary @- ... )`
+// with a fairly fancy set of retry options to curl, and it may eventually be replaced by just such
+// a script.
 //
-// If the -auth-file option is provided then the file named must provide a user name and password on
-// the form username/password, to be used in an HTTP basic authentication header.  If the connection
-// is not HTTPS then the password may be intercepted in transit.
+// Usage:
 //
-// If the -ca-cert opton is provided then the URL must be an HTTPS URL (and vice versa), and the
-// argument is a filename holding the certificate for a Certificate Authority that exfiltrate will
-// use to validate the identity of the server.
+//   exfiltrate [options] target-url
 //
-// For example, with a sending window of 300s:
+//   The target-url is mandatory: It is an HTTP or HTTPS URL, including path and arguments, to which
+//   data are sent by POST.
+//
+// The mimetype can and usually should be specified:
+//
+// -mimetype <type>
+//   The default type is text/plain.
+//
+// Sending can be randomized:
+//
+// -window <seconds>
+//   Specifies the sending window in seconds, a random time within the window is chosen for the first
+//   sending attempt.  The default window is 0.
+//
+// Network transport can be HTTPS:
+//
+// -ca-cert <filename>
+//   The URL must be an HTTPS URL, and the argument is a filename holding the certificate for a
+//   Certificate Authority that exfiltrate will use to validate the identity of the server.
+//
+// Upload can be authenticated:
+//
+// -auth-file <filename>
+//   The file named must provide a user name and password on the form username:password, to be used
+//   in an HTTP basic authentication header.  If the connection is not HTTPS then the password may
+//   be intercepted in transit.
+//
+// There is online help:
+//
+// -h
+//   Print help
+//
+// Debugging options:
+//
+// -v
+//   Verbose diagnostics
+//
+// For example:
 //
 //   sonar ps ... | \
-//      exfiltrate -window 300 -cluster ml -source sonar/csvnamed -output json \
-//                 -ca-cert secrets/server-ca.crt -target https://...
+//      exfiltrate -window 300 -ca-cert secrets/server-ca.crt -auth-file my-password.txt \
+//          https://naic-monitor.uio.no/sonar-freecsv?cluster=mlx.hpc.uio.no
 //
-// Source formats supported
+// About logging:
 //
-//   "sonar/csvnamed"
-//     Mixed reading and heartbeat records from sonar on "csvnamed" format (CSV syntax with
-//     name=value syntax for each field)
+// Exfiltrate currently logs to stdout/stderr with the expectation that it will be run by cron and
+// that there is a sensible MAILTO set up in the crontab to route any output to a responsible user.
+// All output (for runs without -v) will pertain to errors.
 //
-// Output (transmission) formats supported
-//
-//   "json"
-//     The data are transmitted as JSON arrays-of-objects where each object is a reading or
-//     heartbeat record.
-//
-// Target URL schemes: "http", "https"
-//
-// For HTTP POST transmission, measurement data are posted to <target-address>/sonar-reading and
-// heartbeat data are posted to <target-address>/sonar-heartbeat.  The cluster tag is injected as a
-// new field "cluster" in all the Sonar records of both kinds.
-//
-// For future formats and schemes, see README.md.
-//
-// About logging: Exfiltrate currently logs to stdout/stderr with the expectation that it will be
-// run by cron and that there is a sensible MAILTO set up in the crontab to route any output to a
-// responsible user.  All output (for runs without -v) will pertain to errors.
+// TODO: Could parameterize the resend attempts and interval.
 
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -67,8 +82,6 @@ import (
 
 	"go-utils/auth"
 	"go-utils/httpclient"
-	jsonutil "go-utils/json"
-	"go-utils/sonarlog"
 	"go-utils/status"
 )
 
@@ -79,12 +92,20 @@ const (
 	resendIntervalMin = 5
 )
 
-var verbose bool
+// Command line parameters
+var (
+	window     int
+	mimetype   string
+	authFile   string
+	caCertFile string
+	target     *url.URL
+	verbose    bool
+)
 
 func main() {
 	status.Start("jobanalyzer/exfiltrate")
 
-	window, cluster, inputSource, inputType, outputType, authFile, caCert, target, err := commandLine()
+	err := commandLine()
 	if err != nil {
 		status.Fatalf("Command line: %v", err)
 	}
@@ -105,25 +126,6 @@ func main() {
 		fmt.Printf("Bytes of data read: %d\n", len(bs))
 	}
 
-	var readings []*sonarlog.SonarReading
-	var heartbeats []*sonarlog.SonarHeartbeat
-	if inputSource == "sonar" && inputType == "csvnamed" {
-		var badRecords int
-		readings, heartbeats, badRecords, err = sonarlog.ParseSonarCsvnamed(bytes.NewReader(bs))
-		if err != nil {
-			status.Fatalf("Failed to parse input as csvnamed: %v", err)
-		}
-		if badRecords > 0 {
-			status.Infof("Bad records and/or fields: %d", badRecords)
-		}
-	} else {
-		panic("Unexpected input type / source combination")
-	}
-
-	if verbose {
-		fmt.Printf("Readings: %d, heartbeats: %d\n", len(readings), len(heartbeats))
-	}
-
 	if window > 0 {
 		secs := rand.Intn(window)
 		if verbose {
@@ -135,132 +137,52 @@ func main() {
 	if target.Scheme != "http" && target.Scheme != "https" {
 		status.Fatal("Only http / https targets for now")
 	}
-	if target.Scheme == "https" && caCert == "" {
+	if target.Scheme == "https" && caCertFile == "" {
 		status.Fatal("HTTPS requires a -ca-cert")
 	}
-	if target.Scheme == "http" && caCert != "" {
+	if target.Scheme == "http" && caCertFile != "" {
 		status.Fatal("HTTP needs no -ca-cert; did you mean HTTPS?")
 	}
 
-	client, err := httpclient.NewClient(target, caCert, authUser, authPass, maxAttempts, resendIntervalMin, verbose)
+	client, err := httpclient.NewClient(target, caCertFile, authUser, authPass, maxAttempts, resendIntervalMin, verbose)
 	if err != nil {
 		status.Fatalf("Failed to create client: %v", err)
 	}
-	switch outputType {
-	case "json":
-		if len(readings) > 0 {
-			for _, r := range readings {
-				// Tag the record with the cluster name if it isn't already tagged.
-				if r.Cluster == "" {
-					r.Cluster = cluster
-				}
-				// Remove JSON-unrepresentable Infinity and NaN values, as they appear in older data.
-				r.CpuPct = jsonutil.CleanFloat64(r.CpuPct)
-				r.GpuPct = jsonutil.CleanFloat64(r.GpuPct)
-				r.GpuMemPct = jsonutil.CleanFloat64(r.GpuMemPct)
-			}
-			buf, err := json.Marshal(&readings)
-			if err != nil {
-				status.Fatalf("Failed to marshal: %v", err)
-			}
-			client.PostDataByHttp("/sonar-reading", "application/json", buf)
-		}
-
-		if len(heartbeats) > 0 {
-			for _, h := range heartbeats {
-				if h.Cluster == "" {
-					h.Cluster = cluster
-				}
-			}
-			buf, err := json.Marshal(&heartbeats)
-			if err != nil {
-				status.Fatalf("Failed to marshal: %v", err)
-			}
-			client.PostDataByHttp("/sonar-heartbeat", "application/json", buf)
-		}
-
-	default:
-		panic("Bad output type")
-	}
-
-	// Data for a packet that could not be delivered go into a queue and a re-send attempt is made
-	// after some minutes by ProcessRetries.  The exfiltrate process stays alive, but the sonar
-	// process that created the data should be able to exit on its own as we've read all the data.
-	// Another run of Sonar may start up another exfiltrate meanwhile.  This is OK, as records may
-	// arrive out-of-order at the destination.  There is a hard limit on the number of retries per
-	// packet, after which the record is dropped on the floor.  The exfiltrate process exits when
-	// the retry queue is empty.
-
+	client.PostDataByHttp("", mimetype, bs)
 	client.ProcessRetries()
 }
 
-func commandLine() (
-	window int,
-	cluster, inputSource, inputType, outputType, authFile, caCert string,
-	target *url.URL,
-	err error,
-) {
+func commandLine() error {
 	flags := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flags.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [options] target-url\nOptions:\n", os.Args[0])
+		flags.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(), "  target-url\n    \tDestination for data\n")
+	}
+	flags.StringVar(&mimetype, "mimetype", "text/plain", "The `mime type` of the data")
 	flags.IntVar(&window, "window", 0, "Send data inside a window of this many `seconds`")
-	flags.StringVar(&cluster, "cluster", "", "Tag the data as coming from `cluster-name` (required)")
-	var sourceArg string
-	flags.StringVar(&sourceArg, "source", "", "Assume input data are in this `format` (required)")
-	flags.StringVar(&outputType, "output", "", "Transmit data in this `format` (required)")
-	var targetArg string
-	flags.StringVar(&targetArg, "target", "", "Connect to `url` to upload data (required)")
 	flags.StringVar(&authFile, "auth-file", "", "Read upload credentials from `filename`")
-	flags.StringVar(&caCert, "ca-cert", "", "Connect over HTTPS with CA cert `filename`")
+	flags.StringVar(&caCertFile, "ca-cert", "", "Connect over HTTPS with CA cert `filename`")
 	flags.BoolVar(&verbose, "v", false, "Verbose information")
-	err = flags.Parse(os.Args[1:])
+	err := flags.Parse(os.Args[1:])
 	if err == flag.ErrHelp {
 		os.Exit(0)
 	}
 	if err != nil {
-		return
+		return err
 	}
-
-	if cluster == "" {
-		err = errors.New("Argument -cluster is required")
-		return
+	if len(flags.Args()) != 1 {
+		return fmt.Errorf("Exactly one target argument is required")
 	}
-
-	if sourceArg == "" {
-		err = errors.New("Argument -source is required")
-		return
-	}
-	if sourceArg != "sonar/csvnamed" {
-		// This is expected to change
-		err = errors.New("Unknown --source value")
-		return
-	}
-	inputSource = "sonar"
-	inputType = "csvnamed"
-
-	if outputType == "" {
-		err = errors.New("Argument -output is required")
-		return
-	}
-	if outputType != "json" {
-		// This is expected to change
-		err = errors.New("-output must be `json`")
-		return
-	}
-
-	if targetArg == "" {
-		err = errors.New("Argument -target is required")
-		return
-	}
-	// TODO: Validation.  The parser seems to accept pretty much anything.  Probably we require
-	// scheme://host:port and no path on the host and no query.  What about userinfo in the host
-	// field?
+	targetArg := flags.Args()[0]
 	target, err = url.Parse(targetArg)
-	if err != nil || target.Scheme == "" || target.Host == "" || target.Path != "" {
+	if err != nil || target.Scheme == "" || target.Host == "" {
 		errmsg := ""
 		if err != nil {
 			errmsg = fmt.Sprintf(": %v", err)
 		}
-		err = fmt.Errorf("Failed to parse target URL %s%s", target, errmsg)
+		return fmt.Errorf("Failed to parse target URL %s%s", target, errmsg)
 	}
 
-	return
+	return nil
 }

--- a/code/infiltrate/infiltrate.go
+++ b/code/infiltrate/infiltrate.go
@@ -1,39 +1,35 @@
-// `infiltrate` - data receiver for Sonar data, to run on database/analysis host.
+// `infiltrate` - data receiver for node data, to run on database/analysis host.
 //
-// Infiltrate receives JSON-formatted data by HTTP/HTTPS POST on several addresses and stores the data
-// locally for subsequent analysis.  This agent is always running - it's the only contact point for
-// the data producers on the nodes.
-//
-// For the time being, we use the Sonar CSV format and directory structure to store all Sonar data,
-// this allows existing consumers to work without change, just without needing a shared disk with
-// the data producers.  The storage format will change later.
+// Infiltrate receives data (on various formats) by HTTP/HTTPS POST on several service addresses and
+// stores the data locally for subsequent analysis.  This agent is always running - it's the only
+// contact point for the data producers on the nodes - and there can be only one.
 //
 // Options:
 //
-// -data-path `filename`
+// -data-dir `filename`
 //   Required argument.  The root of the data store.
 //
 // -port `port-number`
 //   Optional argument.  Port on which to listen, default is 8086.
 //
 // -auth-file `filename`
-//   Optional argument.  If provided then the file named must provide username:password
-//   combinations, to be matched with one in an HTTP basic authentication header.  (If the
-//   connection is not HTTPS then the password may have been intercepted in transit.)
+//   Optional but *strongly* recommended argument.  If provided then the file named must provide
+//   username:password combinations, to be matched with one in an HTTP basic authentication header.
+//   (If the connection is not HTTPS then the password may have been intercepted in transit.)
 //
 // -match-user-and-cluster
-//   Optional argument.  If set, and -auth-file is also provided, then the user name provided by the
-//   HTTP connection must match the cluster name in the data packet.  The effect is to make it
-//   possible for each cluster to have its own username:password pair and for one cluster not to be
-//   able to upload data for another.
+//   Optional but *strongly* recommended argument.  If set, and -auth-file is also provided, then
+//   the user name provided by the HTTP connection must match the cluster name in the data packet or
+//   query string.  The effect is to make it possible for each cluster to have its own
+//   username:password pair and for one cluster not to be able to upload data for another.
 //
 // -server-cert `filename`
 //   Optional unless -server-key is provided.  Path of a file holding the public certificate of the
-//   HTTPS server.  Only HTTPS traffic is accepted.
+//   HTTPS server.  Only HTTPS traffic will be accepted.
 //
 // -server-key `filename`
 //   Optional unless -server-cert is provided.  Path of a file holding the private key of the
-//   HTTPS server.  Only HTTPS traffic is accepted.
+//   HTTPS server.  Only HTTPS traffic will be accepted.
 //
 // Sending SIGHUP or SIGTERM to infiltrate will shut it down in an orderly manner.
 //
@@ -48,43 +44,90 @@
 //
 // About logging: Infiltrate logs everything to the syslog.  Errors encountered during startup are
 // also logged to stderr.
+//
+// Services and input formats:
+//
+// /sonar-reading
+//    Input is JSON-format Sonar monitoring data: array of go-utils/sonarlog.SonarReading.  Input
+//    fields are checked against that record type: fields that are not known to the type are
+//    dropped.
+//
+// /sonar-heartbeat
+//    Input is JSON-format Sonar heartbeat data: array of go-utils/sonarlog.SonarHeartbeat.  Input
+//    fields are checked against that record type: fields that are not known to the type are
+//    dropped.
+//
+// /sonar-freecsv?cluster=clusterName
+//    Input is "free CSV" format Sonar monitoring and heartbeat data, intermixed, one record per
+//    line.  If -match-user-and-cluster is used then the the user name provided by the HTTP
+//    connection must match the "cluster" parameter, which is always required.  Most input fields
+//    are not checked - the records are always stored verbatim in the database, after checking the
+//    cluster.  However the record must have sensible `time` and `host` fields, or it will be
+//    rejected.
+//
+// /sysinfo?cluster=clusterName
+//    Input is JSON-format system information data: a single record of go-utils/config.SystemConfig.
+//    The cluster parameter is required; cluster name checking is as for /sonar-freecsv.  The record
+//    must have sensible `timestamp` and `hostname` fields, or it will be rejected.
+//
+// Notes about services:
+//
+// /sonar-reading and /sonar-heartbeat serve the same purpose as /sonar-freecsv but are more tightly
+// coupled and probably ahead of their time.  They will make more sense when we are no longer adding
+// functionality to Sonar.
 
 package main
 
 import (
-	"context"
+	"bufio"
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
-	"os/signal"
-	"path"
 	"syscall"
-	"time"
 
 	"go-utils/auth"
+	"go-utils/config"
+	"go-utils/datastore"
+	"go-utils/httpsrv"
 	"go-utils/options"
+	"go-utils/process"
 	"go-utils/sonarlog"
 	"go-utils/status"
 )
 
 const (
-	defaultListenPort        = 8086
-	dirPermissions           = 0755
-	filePermissions          = 0644
-	serverShutdownTimeoutSec = 10
+	defaultListenPort = 8086
 )
-
-var verbose = false
-var programFailed = false
-var matchUserAndCluster = false
 
 func main() {
 	status.Start("jobanalyzer/infiltrate")
+	mainLogic()
+	if programFailed {
+		os.Exit(1)
+	}
+}
 
-	port, httpsKey, httpsCert, dataPath, authFile, err := commandLine()
+// Command-line parameters
+var (
+	matchUserAndCluster bool
+	port                int
+	httpsKey            string
+	httpsCert           string
+	dataDir             string
+	authFile            string
+	verbose             bool
+)
+
+var programFailed bool
+var ds *datastore.Store
+
+func mainLogic() {
+	err := commandLine()
 	if err != nil {
 		status.Fatalf("Command line: %v", err)
 	}
@@ -96,83 +139,35 @@ func main() {
 			status.Fatalf("Failed to read authentication file: %v\n", err)
 		}
 	}
-	go runWriter()
 
-	// TODO: We have shared abstractions for the HTTP server and the signal handling, now.  See
-	// sonalyzed for examples.
+	// Before stopping the writer we must wait for the web server to stop, so that no more records
+	// will arrive in the waiter.
+	ds = datastore.Open(dataDir, verbose)
+	defer ds.Close()
 
-	go runServer(port, httpsKey, httpsCert, dataPath, authenticator)
-	// Hang until SIGHUP or SIGTERM, then shut down orderly.
-	stopSignal := make(chan os.Signal, 1)
-	signal.Notify(stopSignal, syscall.SIGHUP)  // Sent manually and maybe when logging out?
-	signal.Notify(stopSignal, syscall.SIGTERM) // Sent during shutdown
-	<-stopSignal
-	stopServer()
-	stopWriter()
-	if programFailed {
-		os.Exit(1)
-	}
-}
-
-var serverStopChannel = make(chan bool)
-var server *http.Server
-
-func runServer(port int, httpsKey, httpsCert, dataPath string, authenticator *auth.Authenticator) {
-	http.HandleFunc(
-		"/sonar-reading",
-		incomingData(
-			authenticator,
-			func(payload []byte, clusterName string) (int, string, string) {
-				return sonarReading(payload, dataPath, clusterName)
-			}),
-	)
-	http.HandleFunc(
-		"/sonar-heartbeat",
-		incomingData(
-			authenticator,
-			func(payload []byte, clusterName string) (int, string, string) {
-				return sonarHeartbeat(payload, dataPath, clusterName)
-			}),
-	)
+	http.HandleFunc("/sonar-reading", incomingData(authenticator, "application/json", sonarReading))
+	http.HandleFunc("/sonar-heartbeat", incomingData(authenticator, "application/json", sonarHeartbeat))
+	http.HandleFunc("/sonar-freecsv", incomingData(authenticator, "text/csv", sonarFreeCsv))
+	http.HandleFunc("/sysinfo", incomingData(authenticator, "application/json", sysinfo))
 	if verbose {
 		status.Infof("Listening on port %d", port)
 	}
-	var err error
-	if httpsKey != "" {
-		hn, err := os.Hostname()
-		if err == nil {
-			server = &http.Server{Addr: fmt.Sprintf("%s:%d", hn, port)}
-			err = server.ListenAndServeTLS(httpsCert, httpsKey)
-		}
-	} else {
-		server = &http.Server{Addr: fmt.Sprintf(":%d", port)}
-		err = server.ListenAndServe()
-	}
-	if err != nil {
-		if err != http.ErrServerClosed {
-			status.Error(err.Error())
-			status.Error("SERVER NOT RUNNING")
-			// TODO: This is ugly, though legal
-			programFailed = true
-		} else {
-			status.Info(err.Error())
-		}
-	}
-	serverStopChannel <- true
-}
 
-func stopServer() {
-	ctx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeoutSec*time.Second)
-	defer cancel()
-	if err := server.Shutdown(ctx); err != nil {
-		status.Warning(err.Error())
-	}
-	<-serverStopChannel
+	s := httpsrv.New(verbose, port, func(err error) {
+		programFailed = true
+	})
+	go s.Start()
+	defer s.Stop()
+
+	// Wait here until we're stopped by SIGHUP (manual) or SIGTERM (from OS during shutdown).
+	// TODO: For SIGHUP, we should not exit but should instead reread any config files.
+	process.WaitForSignal(syscall.SIGHUP, syscall.SIGTERM)
 }
 
 func incomingData(
 	authenticator *auth.Authenticator,
-	dataHandler func([]byte, string) (int, string, string),
+	contentType string,
+	dataHandler func(url.Values, []byte, string) (int, string, string),
 ) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if verbose {
@@ -200,7 +195,7 @@ func incomingData(
 		}
 
 		ct, ok := r.Header["Content-Type"]
-		if !ok || ct[0] != "application/json" {
+		if !ok || ct[0] != contentType {
 			w.WriteHeader(400)
 			fmt.Fprintf(w, "Bad content-type")
 			contentType := "(no type)"
@@ -214,7 +209,8 @@ func incomingData(
 		}
 
 		user, pass, ok := r.BasicAuth()
-		passed := !ok && authenticator == nil || ok && authenticator != nil && authenticator.Authenticate(user, pass)
+		passed := !ok && authenticator == nil ||
+			ok && authenticator != nil && authenticator.Authenticate(user, pass)
 		if !passed {
 			w.WriteHeader(401)
 			fmt.Fprintf(w, "Unauthorized")
@@ -239,7 +235,7 @@ func incomingData(
 			haveRead += n
 		}
 
-		code, msg, logmsg := dataHandler(payload, user)
+		code, msg, logmsg := dataHandler(r.URL.Query(), payload, user)
 
 		// If we don't do anything then the result will just be 200 OK.
 		if code != 200 {
@@ -252,7 +248,7 @@ func incomingData(
 	}
 }
 
-func sonarReading(payload []byte, dataPath, clusterName string) (int, string, string) {
+func sonarReading(_ url.Values, payload []byte, clusterName string) (int, string, string) {
 	var rs []*sonarlog.SonarReading
 	err := json.Unmarshal(payload, &rs)
 	if err != nil {
@@ -261,13 +257,13 @@ func sonarReading(payload []byte, dataPath, clusterName string) (int, string, st
 	}
 	for _, r := range rs {
 		if !matchUserAndCluster || clusterName == "" || r.Cluster == clusterName {
-			writeRecord(dataPath, r.Cluster, r.Host, r.Timestamp, r.Csvnamed())
+			ds.Write(r.Cluster, r.Host, r.Timestamp, "%s.csv", r.Csvnamed())
 		}
 	}
 	return 200, "", ""
 }
 
-func sonarHeartbeat(payload []byte, dataPath, clusterName string) (int, string, string) {
+func sonarHeartbeat(_ url.Values, payload []byte, clusterName string) (int, string, string) {
 	var rs []*sonarlog.SonarHeartbeat
 	err := json.Unmarshal(payload, &rs)
 	if err != nil {
@@ -276,163 +272,92 @@ func sonarHeartbeat(payload []byte, dataPath, clusterName string) (int, string, 
 	}
 	for _, r := range rs {
 		if !matchUserAndCluster || clusterName == "" || r.Cluster == clusterName {
-			writeRecord(dataPath, r.Cluster, r.Host, r.Timestamp, r.Csvnamed())
+			ds.Write(r.Cluster, r.Host, r.Timestamp, "%s.csv", r.Csvnamed())
 		}
 	}
 	return 200, "", ""
 }
 
-// There will be only one copy of `infiltrate` running on the server, so data files have only one
-// writer, and we don't need a lock in the file system for concurrent writing.  There is a danger
-// that there's a reader while we're writing but that danger is already there and should be fixed
-// separately.
-//
-// However, each HTTP request is served on a separate goroutine and we don't want to have to deal
-// with mutexing the log files *internally* in `infiltrate`, so we run the writer on a separate
-// goroutine.
-
-type dataRecord struct {
-	dataPath string // command line arg, this existed at startup at least
-	dirname  string // path underneath dataPath
-	filename string // path underneath dataPath
-	payload  []byte // text to write
-	attempts int    // number of attempts so far
+func sonarFreeCsv(query url.Values, payload []byte, clusterName string) (int, string, string) {
+	vs, found := query["cluster"]
+	if !found || len(vs) != 1 {
+		return 400, "Bad parameters", "Bad parameters - missing or repeated 'cluster'"
+	}
+	cluster := vs[0]
+	scanner := bufio.NewScanner(bytes.NewReader(payload))
+	for scanner.Scan() {
+		text := scanner.Text()
+		fields, err := sonarlog.GetCsvFields(text)
+		if err != nil {
+			return 400, "Bad content",
+				fmt.Sprintf("Bad content - can't unmarshal Sonar free CSV: %v", err)
+		}
+		host := fields["host"]
+		time := fields["time"]
+		if host == "" || time == "" {
+			return 400, "Bad content",
+				fmt.Sprintf("Bad content - missing fields in Sonar free CSV")
+		}
+		if !matchUserAndCluster || clusterName == "" || cluster == clusterName {
+			ds.Write(cluster, host, time, "%s.csv", []byte(text))
+		}
+	}
+	return 200, "", ""
 }
 
-const maxAttempts = 6
-const channelCapacity = 1000
-
-var dataChannel = make(chan *dataRecord, channelCapacity)
-var dataStopChannel = make(chan bool)
-
-// To stop the writer, first the caller must wait for the web server to stop so that no more records
-// to will arrive on the dataChannel.  Then send nil on dataChannel to make the writer exit its loop
-// in an orderly way.  Wait for a response from the writer on stopChannel, and we are done.
-//
-// We don't care about any of the pending retry writes - their sleeping goroutines will either be
-// terminated when the program exits, or will wake up and send data on a channel nobody's listening
-// on before that.  Either way this is invisible.
-
-func stopWriter() {
-	dataChannel <- nil
-	<-dataStopChannel
-}
-
-// writeRecord is infallible, all operations that could fail are performed in the runWriter loop.
-
-func writeRecord(dataPath, cluster, host, timestamp string, payload []byte) {
-	// The path will be (below dataPath) cluster/year/month/day/hostname.csv
-	tval, err := time.Parse(time.RFC3339, timestamp)
+func sysinfo(query url.Values, payload []byte, clusterName string) (int, string, string) {
+	vs, found := query["cluster"]
+	if !found || len(vs) != 1 {
+		return 400, "Bad parameters", "Bad parameters - missing or repeated 'cluster'"
+	}
+	cluster := vs[0]
+	var info config.SystemConfig
+	err := json.Unmarshal(payload, &info)
 	if err != nil {
-		if verbose {
-			status.Warningf("Bad timestamp %s, dropping record", timestamp)
-		}
+		return 400, "Bad content",
+			fmt.Sprintf("Bad content - can't unmarshal Sysinfo JSON: %v", err)
 	}
-	dirname := fmt.Sprintf("%s/%04d/%02d/%02d", cluster, tval.Year(), tval.Month(), tval.Day())
-	filename := fmt.Sprintf("%s/%s.csv", dirname, host)
-
-	dataChannel <- &dataRecord{dataPath, dirname, filename, payload, 0}
+	if info.Timestamp == "" || info.Hostname == "" {
+		// Older versions of `sysinfo`
+		return 400, "Bad content",
+			fmt.Sprintf("Bad content - no timestamp")
+	}
+	if !matchUserAndCluster || clusterName == "" || cluster == clusterName {
+		ds.Write(cluster, info.Hostname, info.Timestamp, "sysinfo-%s.json", payload)
+	}
+	return 200, "", ""
 }
 
-// TODO: Optimization: Cache open files for a time.
-
-func runWriter() {
-	for {
-		r := <-dataChannel
-		if r == nil {
-			break
-		}
-		r.attempts++
-		if verbose {
-			fmt.Printf("Storing: %s", string(r.payload))
-		}
-
-		err := os.MkdirAll(path.Join(r.dataPath, r.dirname), dirPermissions)
-		if err != nil {
-			// Could be disk full, fs went away, element of path exists as file, wrong permissions
-			maybeRetry(r, fmt.Sprintf("Failed to create path (%v)", err))
-			return
-		}
-		f, err := os.OpenFile(
-			path.Join(r.dataPath, r.filename),
-			os.O_APPEND|os.O_CREATE|os.O_WRONLY,
-			filePermissions,
-		)
-		if err != nil {
-			// Could be disk full, fs went away, file is directory, wrong permissions
-			maybeRetry(r, fmt.Sprintf("Failed to open/create file (%v)", err))
-			return
-		}
-		n, err := f.Write(r.payload)
-		f.Close()
-		if err != nil {
-			if n == 0 {
-				// Nothing was written so try to recover by restarting.
-				maybeRetry(r, fmt.Sprintf("Failed to write file (%v)", err))
-			} else {
-				// Partial data were written.
-				//
-				// The usual and benign reason for a partial write on Unix is that a signal was
-				// delivered in the middle of a write and the write needs to restart with the rest
-				// of the data; this is signalled with an EINTR error return from write(2).  The Go
-				// libraries try to hide that problem - see internal/poll/fd_unix.go in the Go
-				// sources, the function Write() is the normal destination for file output.  It
-				// calls ignoringEINTRIO(syscall.Write) to perform the write, and that in turn will
-				// restart the write in the case of EINTR.
-				//
-				// Of course, "transparently restarting after writing some data" in O_APPEND mode is
-				// a complete fiction, but what can you do.
-				//
-				// Anyway, if we get here with a partial data write it's going to be something more
-				// serious than EINTR, such as a disk full.  Trying to recover is probably not worth
-				// our time.  Just log the failure and hope somebody sees it.
-				status.Errorf("Write error on log (%v), %d bytes written of %d",
-					err, n, len(r.payload))
-			}
-		}
-	}
-	dataStopChannel <- true
-}
-
-func maybeRetry(r *dataRecord, msg string) {
-	if r.attempts < maxAttempts {
-		if verbose {
-			status.Info(msg + ", retrying later")
-		}
-		go func() {
-			// Obviously some kind of backoff is possible, but do we care?
-			time.Sleep(time.Duration(5 * time.Minute))
-			dataChannel <- r
-		}()
-	} else {
-		status.Warning(msg + ", too many retries, abandoning")
-	}
-}
-
-func commandLine() (port int, httpsKey, httpsCert, dataPath, authFile string, err error) {
+func commandLine() error {
 	flags := flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 	flags.IntVar(&port, "port", defaultListenPort, "Listen for connections on `port`")
 	flags.StringVar(&httpsCert, "server-cert", "",
 		"Listen for HTTPS connections with server cert `filename` (requires -server-key)")
 	flags.StringVar(&httpsKey, "server-key", "",
 		"Listen for HTTPS connections with server key `filename` (requires -server-cert)")
-	flags.StringVar(&dataPath, "data-path", "", "Path of data store root `directory` (required)")
+	flags.StringVar(&dataDir, "data-dir", "", "Root `directory` of data store (required)")
 	flags.StringVar(&authFile, "auth-file", "", "Read user names and passwords from `filename`")
-	flags.BoolVar(&matchUserAndCluster, "match-user-and-cluster", false, "Require user name to match cluster name")
+	flags.BoolVar(&matchUserAndCluster, "match-user-and-cluster", false,
+		"Require user name to match cluster name")
+	var dataPath string
+	flags.StringVar(&dataPath, "data-path", "", "Obsolete name for -data-dir")
 	flags.BoolVar(&verbose, "v", false, "Verbose logging")
-	err = flags.Parse(os.Args[1:])
+	err := flags.Parse(os.Args[1:])
 	if err == flag.ErrHelp {
 		os.Exit(0)
 	}
 	if err != nil {
-		return
+		return err
 	}
-	dataPath, err = options.RequireDirectory(dataPath, "-data-path")
+	if dataDir == "" {
+		dataDir = dataPath
+	}
+	dataDir, err = options.RequireDirectory(dataDir, "-data-dir")
 	if err != nil {
-		return
+		return err
 	}
 	if (httpsCert != "") != (httpsKey != "") {
-		err = fmt.Errorf("Need both -https-cert and -https-key, or neither")
+		return fmt.Errorf("Need both -https-cert and -https-key, or neither")
 	}
-	return
+	return nil
 }

--- a/code/tests/transport/simple-expect.csv
+++ b/code/tests/transport/simple-expect.csv
@@ -1,2 +1,2 @@
-v=0.7.0,time=2023-11-15T00:00:03+01:00,host=myhost,cores=56,memtotalkib=0,user=limeng,job=1511785,pid=0,cmd=python,cpu%=675,cpukib=123249780,rssanonkib=0,"gpus=3,1,2,0",gpu%=396,gpumem%=276,gpukib=37986304,gpufail=0,cputime_sec=2652658,rolledup=36
-v=0.7.0,time=2023-11-15T00:05:03+01:00,host=myhost,cores=56,memtotalkib=0,user=balintl,job=4159295,pid=4159295,cmd=watch,cpu%=0.1,cpukib=1916,rssanonkib=0,gpus=none,gpu%=0,gpumem%=0,gpukib=0,gpufail=0,cputime_sec=2663,rolledup=0
+v=0.7.0,time=2023-11-15T00:00:03+01:00,host=myhost,cores=56,user=limeng,job=1511785,pid=0,cmd=python,cpu%=675,cpukib=123249780,"gpus=3,1,2,0",gpu%=396,gpumem%=276,gpukib=37986304,cputime_sec=2652658,rolledup=36
+v=0.7.0,time=2023-11-15T00:05:03+01:00,host=myhost,cores=56,user=balintl,job=4159295,pid=4159295,cmd=watch,cpu%=0.1,cpukib=1916,gpus=none,gpu%=0,gpumem%=0,gpukib=0,cputime_sec=2663

--- a/code/tests/transport/simple.sh
+++ b/code/tests/transport/simple.sh
@@ -11,7 +11,7 @@ mkdir -p $tmpdir
 # Note if infiltrate fails on startup the `set -e` will not catch it because the server is run in
 # the background.  In this case, $infiltrate_pid will reference a process that is not there.
 
-$INFILTRATE -data-path $tmpdir -port $testport -auth-file test-auth.txt &
+$INFILTRATE -data-dir $tmpdir -port $testport -auth-file test-auth.txt &
 infiltrate_pid=$!
 
 # Always attempt to shut down the server on exit.  (Not sure if the HUP/INT are necessary or if they
@@ -24,19 +24,15 @@ sleep 1
 cat simple-data1.csv | \
     $EXFILTRATE \
         -window 0 \
-        -cluster test \
-        -source sonar/csvnamed \
-        -output json \
-        -target http://localhost:$testport \
-        -auth-file test-auth.txt
+        -auth-file test-auth.txt \
+        -mimetype text/csv \
+        http://localhost:$testport/sonar-freecsv?cluster=test
 cat simple-data2.csv | \
     $EXFILTRATE \
         -window 0 \
-        -cluster test \
-        -source sonar/csvnamed \
-        -output json \
-        -target http://localhost:$testport \
-        -auth-file test-auth.txt
+        -auth-file test-auth.txt \
+        -mimetype text/csv \
+        http://localhost:$testport/sonar-freecsv?cluster=test
 
 # Wait for messages to be processed by infiltrate
 sleep 1


### PR DESCRIPTION
Infiltrate is rewritten using the better libraries, and has two new services: /sonar-freecsv and /sonar-sysinfo.  The old JSON services remain.

Exfiltrate has been rewritten and is now just a data forwarding agent, it does not inspect its data at all.