### PR TITLE
No bug: Make test cases run on Darwin

### DIFF
--- a/code/build.sh
+++ b/code/build.sh
@@ -31,7 +31,9 @@ echo "======================================================================="
 echo " SYSINFO RELEASE BUILD + SMOKE TEST"
 echo "======================================================================="
 ( cd sysinfo ; go build )
-( cd sysinfo ; ./sysinfo -h 2&> /dev/null )
+if [[ $(uname) != Darwin ]]; then
+    ( cd sysinfo ; ./sysinfo -h 2&> /dev/null )
+fi
 
 echo "======================================================================="
 echo " EXFILTRATE RELEASE BUILD + SMOKE TEST"

--- a/code/go-utils/run_tests.sh
+++ b/code/go-utils/run_tests.sh
@@ -12,5 +12,7 @@ echo "======================================================================="
 ( cd freecsv ; go test )
 ( cd hostglob ; go test )
 ( cd sonarlog ; go test )
-( cd sysinfo ; go test )
+if [[ $(uname) != Darwin ]]; then
+    ( cd sysinfo ; go test )
+fi
 ( cd time ; go test )

--- a/code/run_tests.sh
+++ b/code/run_tests.sh
@@ -46,7 +46,9 @@ echo "======================================================================="
 echo " SYSINFO RELEASE BUILD + SMOKE TEST"
 echo "======================================================================="
 ( cd sysinfo ; go build )
-( cd sysinfo ; ./sysinfo -h 2&> /dev/null )
+if [[ $(uname) != Darwin ]]; then
+    ( cd sysinfo ; ./sysinfo -h 2&> /dev/null )
+fi
 
 echo "======================================================================="
 echo " EXFILTRATE RELEASE BUILD + SMOKE TEST"

--- a/code/tests/naicreport/ml-cpuhog/mlcpuhog.sh
+++ b/code/tests/naicreport/ml-cpuhog/mlcpuhog.sh
@@ -35,9 +35,9 @@ CHECK cpuhog_final_state 8 "$output"
 rm -f $statefile
 
 output=$($NAICREPORT ml-cpuhog --state-file $statefile --summary --json -- cpuhog1.csv | sort)
-CHECK cpuhog_regression_220_part1 "1" "$(echo $output | grep pubuduss | wc -l)"
+CHECK cpuhog_regression_220_part1 "1" "$(echo $output | grep pubuduss | wc -l | tr -d ' ')"
 
 output=$($NAICREPORT ml-cpuhog --to 2023-10-25 --state-file $statefile --summary --json -- cpuhog2.csv | sort)
-CHECK cpuhog_regression_220_part2 "1" "$(echo $output | grep tsauren | wc -l)"
+CHECK cpuhog_regression_220_part2 "1" "$(echo $output | grep tsauren | wc -l | tr -d ' ')"
 
 rm -f $statefile

--- a/code/tests/run_tests.sh
+++ b/code/tests/run_tests.sh
@@ -30,8 +30,10 @@
 #
 # The pattern is a regex pattern that must match the name of the test filname.
 
-TEST_DIRECTORIES="sonarlog sonalyze sonard naicreport transport slurminfo"
-
+TEST_DIRECTORIES="sonarlog sonalyze naicreport slurminfo"
+if [[ $(uname) != Darwin ]]; then
+    TEST_DIRECTORIES="$TEST_DIRECTORIES sonard transport"
+fi
 export TEST_ROOT=$(pwd)
 export SONALYZE=$TEST_ROOT/../sonalyze/target/debug/sonalyze
 export NAICREPORT=$TEST_ROOT/../naicreport/naicreport


### PR DESCRIPTION
Things that don't run:
- transport tests (b/c Darwin wants to ask for permission for sockets opening)
- sonard (b/c no Sonar)
- sysinfo (b/c not Linux)
