### PR TITLE
Optimize csv parsing further

### DIFF
--- a/code/go-utils/sonarlog/csv.go
+++ b/code/go-utils/sonarlog/csv.go
@@ -150,7 +150,7 @@ LineLoop:
 					}
 					timestamp = tmp.Unix()
 				case 1:
-					hostname = ustrs.Alloc(string(val))
+					hostname = ustrs.AllocBytes(val)
 				case 2:
 					var tmp uint64
 					tmp, err = parseUint(val)
@@ -161,7 +161,7 @@ LineLoop:
 					}
 					numCores = uint32(tmp)
 				case 3:
-					user = ustrs.Alloc(string(val))
+					user = ustrs.AllocBytes(val)
 				case 4:
 					var tmp uint64
 					tmp, err = parseUint(val)
@@ -173,7 +173,7 @@ LineLoop:
 					jobId = uint32(tmp)
 					pid = jobId
 				case 5:
-					command = ustrs.Alloc(string(val))
+					command = ustrs.AllocBytes(val)
 				case 6:
 					var tmp float64
 					tmp, err = parseFloat(val)

--- a/code/go-utils/sonarlog/csv.go
+++ b/code/go-utils/sonarlog/csv.go
@@ -7,22 +7,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"strconv"
 	"strings"
 	"time"
 )
-
-func match(f, k string) (string, bool) {
-	if len(f) <= len(k) || f[len(k)] != '=' {
-		return "", false
-	}
-	for i, c := range k {
-		if rune(f[i]) != c {
-			return "", false
-		}
-	}
-	return f[len(k)+1:], true
-}
 
 // Sonar data intermingle readings and heartbeats (though really only in the tagged format).  Read a
 // stream of records, parse them into separate buckets and return the buckets.  Returns the number
@@ -40,255 +29,435 @@ func ParseSonarLog(
 ) (
 	readings []*SonarReading,
 	heartbeats []*SonarHeartbeat,
-	badRecords int,
+	discarded int,
 	err error,
 ) {
+	const (
+		unknownFormat = iota
+		untaggedFormat
+		taggedFormat
+	)
 
-	rdr := csv.NewReader(input)
-	// CSV rows are arbitrarily wide and possibly uneven.
-	rdr.FieldsPerRecord = -1
 	readings = make([]*SonarReading, 0)
 	heartbeats = make([]*SonarHeartbeat, 0)
+	tokenizer := NewTokenizer(input)
 	v060 := ustrs.Alloc("0.6.0")
 	heartbeat := ustrs.Alloc("_heartbeat_")
-outerLoop:
-	for {
-		var fields []string
-		fields, err = rdr.Read()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return
-		}
-		if len(fields) == 0 {
-			badRecords++
-			continue outerLoop
-		}
-		r := new(SonarReading)
-		// If the first field starts with a '2' then this is the old untagged format because that's
-		// the first byte in an untagged timestamp, and no tags start with that value.
-		if []byte(fields[0])[0] == '2' {
-			// Old old format (current on Saga and Fram as of 2024-03-04)
-			// 0  timestamp
-			// 1  hostname
-			// 2  numcores
-			// 3  username
-			// 4  jobid
-			// 5  command
-			// 6  cpu_pct
-			// 7  mem_kib
-			//
-			// New old format (what was briefly deployed on the UiO ML nodes)
-			// 8  gpus bitvector
-			// 9  gpu_pct
-			// 10 gpumem_pct
-			// 11 gpumem_kib
-			//
-			// Newer old format (again briefly used on the UiO ML nodes)
-			// 12 cputime_sec
+	endOfInput := false
 
-			if len(fields) < 8 {
-				badRecords++
-				continue outerLoop
-			}
+LineLoop:
+	for !endOfInput {
+		// Find the fields and then convert them.  Duplicates are not allowed.  Mandatory
+		// fields are really required.  The sentinels are not zero because zero are valid values
+		// from the input.  Keep the sentinels in sync with code below that inserts default values
+		// after parsing!
+		var (
+			version                  = UstrEmpty
+			timestamp        int64   = math.MaxInt64
+			hostname                 = UstrEmpty
+			numCores         uint32  = math.MaxUint32
+			memTotalKib      uint64  = math.MaxUint64
+			user                     = UstrEmpty
+			pid              uint32  = math.MaxUint32
+			jobId            uint32  = math.MaxUint32
+			command                  = UstrEmpty
+			cpuPct           float32 = math.MaxFloat32
+			cpuKib           uint64  = math.MaxUint64
+			rssAnonKib       uint64  = math.MaxUint64
+			gpus                     = EmptyGpuSet()
+			haveGpus                 = false
+			gpuPct           float32 = math.MaxFloat32
+			gpuMemPct        float32 = math.MaxFloat32
+			gpuKib           uint64  = math.MaxUint64
+			gpuFail          uint8   = math.MaxUint8
+			cpuTimeSec       uint64  = math.MaxUint64
+			rolledup         uint32  = math.MaxUint32
+			format                   = unknownFormat
+			untaggedPosition         = 0
+			anyFields                = false
+		)
 
-			r.Version = v060
-			ts, err := time.Parse(time.RFC3339Nano, fields[0])
+	FieldLoop:
+		for {
+			var start, lim, eqloc int
+			var matched bool
+			start, lim, eqloc, err = tokenizer.Get()
 			if err != nil {
-				badRecords++
-				continue outerLoop
-			}
-			r.Timestamp = ts.Unix()
-			r.Host = ustrs.Alloc(fields[1])
-			cores, err := strconv.ParseUint(fields[2], 10, 64)
-			if err != nil {
-				badRecords++
-				continue outerLoop
-			}
-			r.Cores = uint32(cores)
-			r.User = ustrs.Alloc(fields[3])
-			jobno, err := strconv.ParseUint(fields[4], 10, 64)
-			if err != nil {
-				badRecords++
-				continue outerLoop
-			}
-			r.Job = uint32(jobno)
-			r.Pid = r.Job
-			r.Cmd = ustrs.Alloc(fields[5])
-			cpupct, err := strconv.ParseFloat(fields[6], 64)
-			if err != nil {
-				badRecords++
-				continue outerLoop
-			}
-			r.CpuPct = float32(cpupct)
-			r.CpuKib, err = strconv.ParseUint(fields[7], 10, 64)
-			if err != nil {
-				badRecords++
-				continue outerLoop
-			}
-			// Skip any remaining fields - they are not in most untagged data.
-		} else {
-			for _, f := range fields {
-				var cores, jobno, pidno, gpufail, rolledup uint64
-				var cpupct, gpupct, gpumempct float64
-				var ts time.Time
-				matched := false
-				if len(f) < 2 {
-					badRecords++
-					continue outerLoop
+				if !errors.Is(err, SyntaxErr) {
+					return
 				}
-				switch f[0] {
+				tokenizer.ScanEol()
+				discarded++
+				continue LineLoop
+			}
+
+			if start == CsvEol {
+				break FieldLoop
+			}
+
+			if start == CsvEof {
+				endOfInput = true
+				break FieldLoop
+			}
+
+			if format == unknownFormat {
+				if eqloc == CsvEqSentinel {
+					format = untaggedFormat
+					version = v060
+				} else {
+					format = taggedFormat
+				}
+			}
+
+			// Regarding timestamps: This is the format we use in the Sonar logs, but the nano part
+			// is often omitted by our formatters:
+			//
+			//  "2006-01-02T15:04:05.999999999-07:00"
+			//
+			// time.RFC3339Nano handles +/- for the tz offset and also will allow the nano part to
+			// be missing.
+
+			switch format {
+			case unknownFormat:
+				panic("Unexpected state - unknown format")
+
+			case untaggedFormat:
+				// Old old format (current on Saga and Fram as of 2024-03-04)
+				// 0  timestamp
+				// 1  hostname
+				// 2  numcores
+				// 3  username
+				// 4  jobid
+				// 5  command
+				// 6  cpu_pct
+				// 7  mem_kib
+				//
+				// New old format (what was briefly deployed on the UiO ML nodes)
+				// 8  gpus bitvector
+				// 9  gpu_pct
+				// 10 gpumem_pct
+				// 11 gpumem_kib
+				//
+				// Newer old format (again briefly used on the UiO ML nodes)
+				// 12 cputime_sec
+				val := tokenizer.BufSubstring(start, lim)
+				switch untaggedPosition {
+				case 0:
+					var tmp time.Time
+					tmp, err = time.Parse(time.RFC3339Nano, val)
+					if err != nil {
+						discarded++
+						tokenizer.ScanEol()
+						continue LineLoop
+					}
+					timestamp = tmp.Unix()
+				case 1:
+					hostname = ustrs.Alloc(val)
+				case 2:
+					var tmp uint64
+					tmp, err = strconv.ParseUint(val, 10, 64)
+					if err != nil {
+						discarded++
+						tokenizer.ScanEol()
+						continue LineLoop
+					}
+					numCores = uint32(tmp)
+				case 3:
+					user = ustrs.Alloc(val)
+				case 4:
+					var tmp uint64
+					tmp, err = strconv.ParseUint(val, 10, 64)
+					if err != nil {
+						discarded++
+						tokenizer.ScanEol()
+						continue LineLoop
+					}
+					jobId = uint32(tmp)
+					pid = jobId
+				case 5:
+					command = ustrs.Alloc(val)
+				case 6:
+					var tmp float64
+					tmp, err = strconv.ParseFloat(val, 64)
+					if err != nil {
+						discarded++
+						tokenizer.ScanEol()
+						continue LineLoop
+					}
+					cpuPct = float32(tmp)
+				case 7:
+					var tmp uint64
+					tmp, err = strconv.ParseUint(val, 10, 64)
+					if err != nil {
+						discarded++
+						tokenizer.ScanEol()
+						continue LineLoop
+					}
+					cpuKib = tmp
+				default:
+					// Ignore any remaining fields - they are not in most untagged data.
+				}
+				untaggedPosition++
+				matched = true
+				anyFields = true
+
+			case taggedFormat:
+				if eqloc == CsvEqSentinel {
+					// Invalid field syntax: Drop the field but keep the record
+					log.Printf(
+						"Dropping field with bad form: %s", tokenizer.BufSubstring(start, lim),
+					)
+					discarded++
+					continue FieldLoop
+				}
+
+				// The first two characters will always be present because eqloc >= 1.
+				switch tokenizer.BufAt(start) {
 				case 'c':
-					switch f[1] {
+					switch tokenizer.BufAt(start + 1) {
 					case 'o':
-						if val, ok := match(f, "cores"); ok {
-							cores, err = strconv.ParseUint(val, 10, 64)
-							r.Cores = uint32(cores)
+						if val, ok := match(tokenizer, start, lim, eqloc, "cores"); ok {
+							var tmp uint64
+							tmp, err = strconv.ParseUint(val, 10, 64)
+							numCores = uint32(tmp)
 							matched = true
 						}
 					case 'm':
-						if val, ok := match(f, "cmd"); ok {
-							r.Cmd = ustrs.Alloc(val)
+						if val, ok := match(tokenizer, start, lim, eqloc, "cmd"); ok {
+							command = ustrs.Alloc(val)
 							matched = true
 						}
 					case 'p':
-						if val, ok := match(f, "cpu%"); ok {
-							cpupct, err = strconv.ParseFloat(val, 64)
-							r.CpuPct = float32(cpupct)
+						if val, ok := match(tokenizer, start, lim, eqloc, "cpu%"); ok {
+							var tmp float64
+							tmp, err = strconv.ParseFloat(val, 64)
+							cpuPct = float32(tmp)
 							matched = true
-						} else if val, ok := match(f, "cpukib"); ok {
-							r.CpuKib, err = strconv.ParseUint(val, 10, 64)
+						} else if val, ok := match(tokenizer, start, lim, eqloc, "cpukib"); ok {
+							cpuKib, err = strconv.ParseUint(val, 10, 64)
 							matched = true
-						} else if val, ok := match(f, "cputime_sec"); ok {
-							r.CpuTimeSec, err = strconv.ParseUint(val, 10, 64)
+						} else if val, ok := match(tokenizer, start, lim, eqloc, "cputime_sec"); ok {
+							cpuTimeSec, err = strconv.ParseUint(val, 10, 64)
 							matched = true
 						}
 					}
 				case 'g':
-					if val, ok := match(f, "gpu%"); ok {
-						gpupct, err = strconv.ParseFloat(val, 64)
-						r.GpuPct = float32(gpupct)
+					if val, ok := match(tokenizer, start, lim, eqloc, "gpu%"); ok {
+						var tmp float64
+						tmp, err = strconv.ParseFloat(val, 64)
+						gpuPct = float32(tmp)
 						matched = true
-					} else if val, ok := match(f, "gpumem%"); ok {
-						gpumempct, err = strconv.ParseFloat(val, 64)
-						r.GpuMemPct = float32(gpumempct)
+					} else if val, ok := match(tokenizer, start, lim, eqloc, "gpumem%"); ok {
+						var tmp float64
+						tmp, err = strconv.ParseFloat(val, 64)
+						gpuMemPct = float32(tmp)
 						matched = true
-					} else if val, ok := match(f, "gpukib"); ok {
-						r.GpuKib, err = strconv.ParseUint(val, 10, 64)
+					} else if val, ok := match(tokenizer, start, lim, eqloc, "gpukib"); ok {
+						gpuKib, err = strconv.ParseUint(val, 10, 64)
 						matched = true
-					} else if val, ok := match(f, "gpufail"); ok {
-						gpufail, err = strconv.ParseUint(val, 10, 64)
-						r.GpuFail = uint8(gpufail)
+					} else if val, ok := match(tokenizer, start, lim, eqloc, "gpufail"); ok {
+						var tmp uint64
+						tmp, err = strconv.ParseUint(val, 10, 64)
+						gpuFail = uint8(tmp)
 						matched = true
-					} else if val, ok := match(f, "gpus"); ok {
-						r.Gpus, err = NewGpuSet(val)
+					} else if val, ok := match(tokenizer, start, lim, eqloc, "gpus"); ok {
+						gpus, err = NewGpuSet(val)
+						haveGpus = true
 						matched = true
 					}
 				case 'h':
-					if val, ok := match(f, "host"); ok {
-						r.Host = ustrs.Alloc(val)
+					if val, ok := match(tokenizer, start, lim, eqloc, "host"); ok {
+						hostname = ustrs.Alloc(val)
 						matched = true
 					}
 				case 'j':
-					if val, ok := match(f, "job"); ok {
-						jobno, err = strconv.ParseUint(val, 10, 64)
-						r.Job = uint32(jobno)
+					if val, ok := match(tokenizer, start, lim, eqloc, "job"); ok {
+						var tmp uint64
+						tmp, err = strconv.ParseUint(val, 10, 64)
+						jobId = uint32(tmp)
 						matched = true
 					}
 				case 'm':
-					if val, ok := match(f, "memtotalkib"); ok {
-						r.MemtotalKib, err = strconv.ParseUint(val, 10, 64)
+					if val, ok := match(tokenizer, start, lim, eqloc, "memtotalkib"); ok {
+						memTotalKib, err = strconv.ParseUint(val, 10, 64)
 						matched = true
 					}
 				case 'p':
-					if val, ok := match(f, "pid"); ok {
-						pidno, err = strconv.ParseUint(val, 10, 64)
-						r.Pid = uint32(pidno)
+					if val, ok := match(tokenizer, start, lim, eqloc, "pid"); ok {
+						var tmp uint64
+						tmp, err = strconv.ParseUint(val, 10, 64)
+						pid = uint32(tmp)
 						matched = true
 					}
 				case 'r':
-					if val, ok := match(f, "rssanonkib"); ok {
-						r.RssAnonKib, err = strconv.ParseUint(val, 10, 64)
+					// TODO: Switch on second letter?
+					if val, ok := match(tokenizer, start, lim, eqloc, "rssanonkib"); ok {
+						rssAnonKib, err = strconv.ParseUint(val, 10, 64)
 						matched = true
-					} else if val, ok := match(f, "rolledup"); ok {
-						rolledup, err = strconv.ParseUint(val, 10, 64)
-						r.Rolledup = uint32(rolledup)
+					} else if val, ok := match(tokenizer, start, lim, eqloc, "rolledup"); ok {
+						var tmp uint64
+						tmp, err = strconv.ParseUint(val, 10, 64)
+						rolledup = uint32(tmp)
 						matched = true
 					}
 				case 't':
-					if val, ok := match(f, "time"); ok {
-						// This is really the format we use in the logs, but the nano part is often
-						// omitted by our formatters:
-						//
-						//  "2006-01-02T15:04:05.999999999-07:00"
-						//
-						// RFC3339Nano handles +/- for the tz offset and also will allow the nano
-						// part to be missing.
-						ts, err = time.Parse(time.RFC3339Nano, val)
-						r.Timestamp = ts.Unix()
+					if val, ok := match(tokenizer, start, lim, eqloc, "time"); ok {
+						var tmp time.Time
+						tmp, err = time.Parse(time.RFC3339Nano, val)
+						timestamp = tmp.Unix()
 						matched = true
 					}
 				case 'u':
-					if val, ok := match(f, "user"); ok {
-						r.User = ustrs.Alloc(val)
+					if val, ok := match(tokenizer, start, lim, eqloc, "user"); ok {
+						user = ustrs.Alloc(val)
 						matched = true
 					}
 				case 'v':
-					if val, ok := match(f, "v"); ok {
-						r.Version = ustrs.Alloc(val)
+					if val, ok := match(tokenizer, start, lim, eqloc, "v"); ok {
+						version = ustrs.Alloc(val)
 						matched = true
 					}
 				}
 				if !matched {
-					log.Printf("Dropping field with unknown name: %s", f)
-					badRecords++
+					log.Printf(
+						"Dropping field with unknown name: %s", tokenizer.BufSubstring(start, eqloc-1),
+					)
+					if err == nil {
+						discarded++
+					}
 				}
 				if err != nil {
-					log.Printf("Dropping record with illegal/unparseable value: %s %v", f, err)
-					badRecords++
-					continue outerLoop
+					log.Printf(
+						"Dropping record with illegal/unparseable value: %s %v",
+						tokenizer.BufSubstring(start, lim),
+						err,
+					)
+					discarded++
+					tokenizer.ScanEol()
+					continue LineLoop
 				}
+				anyFields = true
+
+			default:
+				panic("Unexpected state")
 			}
 		}
 
+		if !anyFields {
+			continue LineLoop
+		}
+
+		// Fields have been parsed, now check them
 		irritants := ""
-		if r.Version == UstrEmpty || r.Timestamp == 0 || r.Host == UstrEmpty || r.Cmd == UstrEmpty {
-			if r.Version == UstrEmpty {
+		if version == UstrEmpty || timestamp == math.MaxInt64 || hostname == UstrEmpty ||
+			command == UstrEmpty {
+			if version == UstrEmpty {
 				irritants += "version "
 			}
-			if r.Timestamp == 0 {
+			if timestamp == math.MaxInt64 {
 				irritants += "timestamp "
 			}
-			if r.Host == UstrEmpty {
+			if hostname == UstrEmpty {
 				irritants += "host "
 			}
-			if r.Cmd == UstrEmpty {
+			if command == UstrEmpty {
 				irritants += "cmd "
 			}
 		}
-		if r.Cmd != heartbeat && r.User == UstrEmpty {
+		if command != heartbeat && user == UstrEmpty {
 			irritants += "user "
 		}
 		if irritants != "" {
 			log.Printf("Dropping record with missing mandatory field(s): %s", irritants)
-			badRecords++
-			continue outerLoop
+			discarded++
+			continue LineLoop
 		}
 
-		if r.Cmd == heartbeat {
+		// Fill in default data for optional fields.  Keep this code in sync with initialization
+		// above!
+		if numCores == math.MaxUint32 {
+			numCores = 0
+		}
+		if memTotalKib == math.MaxUint64 {
+			memTotalKib = 0
+		}
+		if jobId == math.MaxUint32 {
+			jobId = 0
+		}
+		if pid == math.MaxUint32 {
+			pid = 0
+		}
+		if cpuPct == math.MaxFloat32 {
+			cpuPct = 0
+		}
+		if cpuKib == math.MaxUint64 {
+			cpuKib = 0
+		}
+		if rssAnonKib == math.MaxUint64 {
+			rssAnonKib = 0
+		}
+		if !haveGpus {
+			gpus = EmptyGpuSet()
+		}
+		if gpuPct == math.MaxFloat32 {
+			gpuPct = 0
+		}
+		if gpuMemPct == math.MaxFloat32 {
+			gpuMemPct = 0
+		}
+		if gpuKib == math.MaxUint64 {
+			gpuKib = 0
+		}
+		if gpuFail == math.MaxUint8 {
+			gpuFail = 0
+		}
+		if cpuTimeSec == math.MaxUint64 {
+			cpuTimeSec = 0
+		}
+		if rolledup == math.MaxUint32 {
+			rolledup = 0
+		}
+
+		if command == heartbeat {
 			heartbeats = append(heartbeats, &SonarHeartbeat{
-				Version:   r.Version,
-				Timestamp: r.Timestamp,
-				Host:      r.Host,
+				Version:   version,
+				Timestamp: timestamp,
+				Host:      hostname,
 			})
 		} else {
-			readings = append(readings, r)
+			readings = append(readings, &SonarReading{
+				Version:     version,
+				Timestamp:   timestamp,
+				Host:        hostname,
+				Cores:       numCores,
+				MemtotalKib: memTotalKib,
+				User:        user,
+				Pid:         pid,
+				Job:         jobId,
+				Cmd:         command,
+				CpuPct:      cpuPct,
+				CpuKib:      cpuKib,
+				RssAnonKib:  rssAnonKib,
+				Gpus:        gpus,
+				GpuPct:      gpuPct,
+				GpuMemPct:   gpuMemPct,
+				GpuKib:      gpuKib,
+				GpuFail:     gpuFail,
+				CpuTimeSec:  cpuTimeSec,
+				Rolledup:    rolledup,
+			})
 		}
 	}
 
 	err = nil
 	return
+}
+
+func match(tokenizer *CsvTokenizer, start, lim, eqloc int, tag string) (string, bool) {
+	if tokenizer.MatchTag(tag, start, eqloc) {
+		return tokenizer.BufSubstring(eqloc, lim), true
+	}
+	return "", false
 }
 
 func (r *SonarReading) Csvnamed() []byte {

--- a/code/go-utils/sonarlog/csv_test.go
+++ b/code/go-utils/sonarlog/csv_test.go
@@ -9,7 +9,8 @@ import (
 
 func TestParseSonarLogTagged(t *testing.T) {
 	bs, err := os.ReadFile("../../tests/sonarlog/whitebox-intermingled.csv")
-	readings, heartbeats, bad, err := ParseSonarLog(bytes.NewReader(bs))
+	uf := NewUstrFacade()
+	readings, heartbeats, bad, err := ParseSonarLog(bytes.NewReader(bs), uf)
 	if err != nil {
 		t.Fatalf("Unexpected fatal error during parsing: %v", err)
 	}
@@ -34,7 +35,8 @@ func TestParseSonarLogTagged(t *testing.T) {
 
 func TestParseSonarLogUntagged(t *testing.T) {
 	bs, err := os.ReadFile("../../tests/sonarlog/whitebox-untagged-intermingled.csv")
-	readings, heartbeats, bad, err := ParseSonarLog(bytes.NewReader(bs))
+	uf := NewUstrFacade()
+	readings, heartbeats, bad, err := ParseSonarLog(bytes.NewReader(bs), uf)
 	if err != nil {
 		t.Fatalf("Unexpected fatal error during parsing: %v", err)
 	}
@@ -61,26 +63,26 @@ func TestCsvnamed1(t *testing.T) {
 	now := time.Now().UTC().Unix()
 	noSet, _ := NewGpuSet("unknown")
 	reading := &SonarReading{
-		Version:    StringToUstr("abc"),
-		Timestamp:  now,
-		Cluster:    StringToUstr("bad"), // This is not currently in the csv representation
-		Host:       StringToUstr("hi"),
-		Cores:      5,
+		Version:     StringToUstr("abc"),
+		Timestamp:   now,
+		Cluster:     StringToUstr("bad"), // This is not currently in the csv representation
+		Host:        StringToUstr("hi"),
+		Cores:       5,
 		MemtotalKib: 10,
-		User:       StringToUstr("me"),
-		Job:        37,
-		Pid:        1337,
-		Cmd:        StringToUstr("secret"),
-		CpuPct:     0.5,
-		CpuKib:     12,
-		RssAnonKib: 15,
-		Gpus:       noSet,
-		GpuPct:     0.25,
-		GpuMemPct:  10,
-		GpuKib:     14,
-		GpuFail:    2,
-		CpuTimeSec: 1234,
-		Rolledup:   1,
+		User:        StringToUstr("me"),
+		Job:         37,
+		Pid:         1337,
+		Cmd:         StringToUstr("secret"),
+		CpuPct:      0.5,
+		CpuKib:      12,
+		RssAnonKib:  15,
+		Gpus:        noSet,
+		GpuPct:      0.25,
+		GpuMemPct:   10,
+		GpuKib:      14,
+		GpuFail:     2,
+		CpuTimeSec:  1234,
+		Rolledup:    1,
 	}
 	expected := "v=abc,time=" + time.Unix(now, 0).Format(time.RFC3339) + ",host=hi,user=me,cmd=secret,cores=5,memtotalkib=10,job=37,pid=1337,cpu%=0.5,cpukib=12,rssanonkib=15,gpus=unknown,gpu%=0.25,gpumem%=10,gpukib=14,gpufail=2,cputime_sec=1234,rolledup=1\n"
 	s := string(reading.Csvnamed())
@@ -90,7 +92,7 @@ func TestCsvnamed1(t *testing.T) {
 }
 
 func TestCsvnamed2(t *testing.T) {
-	now := time.Now().UTC().Unix();
+	now := time.Now().UTC().Unix()
 	heartbeat := &SonarHeartbeat{
 		Version:   StringToUstr("abc"),
 		Timestamp: now,

--- a/code/go-utils/sonarlog/csvtokens.go
+++ b/code/go-utils/sonarlog/csvtokens.go
@@ -1,0 +1,212 @@
+// Non-allocating CSV tokenizer.
+//
+// CSV is not a single well-defined format.  Here is what we're parsing:
+//
+//  - the input is UTF-8 / ASCII, no BOM allowed (or needed).
+//  - there is one CSV record per line
+//  - lines are terminated by ASCII newline 0x0A, exclusively
+//  - the terminator is optional at EOF
+//  - blank lines are treated as empty records
+//  - lines have a hardcoded max length given by MAXLINE, below
+//  - there is no header line
+//  - fields are separated by ASCII comma 0x2C, exclusively
+//  - the number of fields can vary between the lines
+//  - fields can be empty
+//  - fields can be enclosed in double-quotes ASCII 0x22 and double-quotes and commas are allowed
+//    inside quoted fields
+//  - newlines and EOF are not allowed inside double-quoted fields
+//  - a double-quote is represented as two double-quotes in a double-quoted field
+//
+// The tokenizer is opened on an io.Reader and provides tokens.  A token is a triplet (A, B, C)
+// where A is either CsvEol, CsvEof (both of which are negative), or a nonnegative value which is
+// the start index into the internal byte buffer.  If A is not CsvEol or CsvEof then B is the
+// one-past-end index into the byte buffer, and C is the index within that range of the character
+// following the first '=', if present, otherwise CsvEqSentinel (which is negative).  The indices
+// are valid until the next call to Get() and can be passed to BufAt() and GetString() to retrieve
+// contents from the internal buffer.
+
+package sonarlog
+
+import (
+	"errors"
+	"io"
+)
+
+const (
+	CsvEol        = -1
+	CsvEof        = -2
+	CsvEqSentinel = -3
+)
+
+const (
+	// The intent of the bufferSize is that sizeof(CsvTokenizer) rounds up to a convenient
+	// allocation block size.  Not sure if this really matters, but we allocate one of these per
+	// input stream.  TODO: It could be stack-allocated and reused.  But then, big stack-allocated
+	// buffer.
+	bufferSize = 65400
+	// 1KB ought to be enough for anyone.
+	maxLine    = 1024
+)
+
+type CsvTokenizer struct {
+	reader      io.Reader
+	ix          int
+	lim         int
+	startOfLine bool
+	failRefill  bool
+	buf         [bufferSize]uint8
+}
+
+func NewTokenizer(reader io.Reader) *CsvTokenizer {
+	return &CsvTokenizer{
+		reader:      reader,
+		startOfLine: true,
+	}
+}
+
+// Extract a string reference into the buffer.  start and lim must have been returned with t.get().
+// This string is only valid until the next call to t.get().
+func (t *CsvTokenizer) GetString(start, lim int) string {
+	if start < 0 || lim < start {
+		panic("Invalid GetString parameters")
+	}
+	return string(t.buf[start:lim])
+}
+
+// Get the byte in the buffer at the given location, this is valid exclusively for locations
+// start..lim returned by a call to t.get().
+func (t *CsvTokenizer) BufAt(loc int) uint8 {
+	return t.buf[loc]
+}
+
+// Get the next token, or an error for syntax errors or I/O errors.
+func (t *CsvTokenizer) Get() (int, int, int, error) {
+	err := t.maybeRefill()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	// The following logic assumes \n is a sentinel at self.buf[self.lim].
+	if t.buf[t.ix] == '\n' {
+		if t.ix == t.lim {
+			return CsvEof, 0, 0, nil
+		}
+		t.ix++
+		t.startOfLine = true
+		return CsvEol, 0, 0, nil
+	}
+
+	if !t.startOfLine {
+		if t.buf[t.ix] != ',' {
+			panic("Must have comma here")
+		}
+		t.ix++
+	}
+
+	// Parse a field, terminated by EOF, EOL, or comma.
+	t.startOfLine = false
+	switch t.buf[t.ix] {
+	case '\n', ',':
+		// Empty field at EOL or EOF or comma
+		return t.ix, t.ix, CsvEqSentinel, nil
+
+	case '"':
+		// This is a little hairy because every doubled quote has to be collapsed into a single one.
+		// We do this in the buffer, hence `destix`.
+		t.ix++
+		startix := t.ix
+		destix := startix
+		eqloc := CsvEqSentinel
+		for {
+			switch t.buf[t.ix] {
+			case '\n':
+				return 0, 0, 0, errors.New("Unexpected end of line or end of file")
+			case '=':
+				if eqloc == CsvEqSentinel {
+					eqloc = t.ix + 1
+				}
+			case '"':
+				t.ix++
+				if t.buf[t.ix] != '"' {
+					// We're done.  We've already consumed the quote.  Check that the
+					// syntax is sane.
+					if t.buf[t.ix] != ',' && t.buf[t.ix] != '\n' {
+						return 0, 0, 0, errors.New("Expected comma or newline after quoted field")
+					}
+					return startix, destix, eqloc, nil
+				}
+			}
+			t.buf[destix] = t.buf[t.ix]
+			destix++
+			t.ix++
+		}
+
+	default:
+		startix := t.ix
+		eqloc := CsvEqSentinel
+		for {
+			switch t.buf[t.ix] {
+			case '\n', ',':
+				return startix, t.ix, eqloc, nil
+			case '=':
+				if eqloc == CsvEqSentinel {
+					eqloc = t.ix + 1
+				}
+			case '"':
+				return 0, 0, 0, errors.New("Unexpected '\"'")
+			}
+			t.ix++
+		}
+	}
+}
+
+// Given start and non-sentinel eqloc values returned with a token and a string <tag>,
+// check if the buffer has the string <tag>= from location start.
+func (t *CsvTokenizer) MatchTag(tag string, start, eqloc int) bool {
+	if start+len(tag)+1 != eqloc {
+		return false
+	}
+	if t.buf[eqloc-1] != '=' {
+		return false
+	}
+	for i := 0; i < len(tag); i++ {
+		if tag[i] != t.buf[start+i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Testing mode: Make the next refill fail with an error that says "Test failure"
+func (t *CsvTokenizer) SetFailRefill() {
+	t.failRefill = true
+}
+
+func (t *CsvTokenizer) maybeRefill() error {
+	// TODO: This was a Rust-ism to fill the buffer with repeated Read calls but it may be that Go
+	// is cleaner and the loop isn't required, just an `if`?
+	for t.lim-t.ix < maxLine {
+		if t.ix != 0 {
+			n := t.lim - t.ix
+			copy(t.buf[0:n], t.buf[t.ix:t.lim])
+			t.ix = 0
+			t.lim = n
+		}
+		if t.failRefill {
+			// Testing mode
+			return errors.New("Test failure")
+		}
+		nread, err := t.reader.Read(t.buf[t.lim : bufferSize-1])
+		if err != nil {
+			if err != io.EOF {
+				return err
+			}
+		}
+		t.lim += nread
+		t.buf[t.lim] = '\n'
+		if nread == 0 {
+			break
+		}
+	}
+	return nil
+}

--- a/code/go-utils/sonarlog/csvtokens.go
+++ b/code/go-utils/sonarlog/csvtokens.go
@@ -84,6 +84,10 @@ func (t *CsvTokenizer) BufSubstring(start, lim int) string {
 	return string(t.buf[start:lim])
 }
 
+func (t *CsvTokenizer) BufSubarray(start, lim int) []byte {
+	return t.buf[start:lim]
+}
+
 var SyntaxErr = errors.New("CSV syntax error")
 
 // Get the next token, or an error for syntax errors or I/O errors.  Syntax errors wrap SyntaxErr.

--- a/code/go-utils/sonarlog/csvtokens_test.go
+++ b/code/go-utils/sonarlog/csvtokens_test.go
@@ -1,0 +1,242 @@
+package sonarlog
+
+import (
+	"bytes"
+	"testing"
+)
+
+// eqloc is either CsvEqSentinel or it's a delta from a
+func checkMatch(t *testing.T, tokenizer *CsvTokenizer, s string, eqloc int) {
+	a, b, c, err := tokenizer.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a < 0 {
+		t.Fatalf("Unexpected start value %d", a)
+	}
+	s2 := tokenizer.GetString(a, b)
+	if s2 != s {
+		t.Fatalf("Not a match for value '%s': '%s'", s, s2)
+	}
+	if (eqloc == CsvEqSentinel && c != eqloc) || (eqloc != CsvEqSentinel && c != a+eqloc) {
+		t.Fatalf("Not a match for eqloc %d: %d", eqloc, c-a)
+	}
+}
+
+// eqloc is either CsvEqSentinel or it's a delta from a
+func checkSentinel(t *testing.T, tokenizer *CsvTokenizer, v int) {
+	a, _, _, err := tokenizer.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != v {
+		t.Fatalf("Unexpected sentinel value %d", a)
+	}
+}
+
+func checkErr(t *testing.T, tokenizer *CsvTokenizer) {
+	_, _, _, err := tokenizer.Get()
+	if err == nil {
+		t.Fatal("Expected error")
+	}
+}
+
+// This tests:
+//  - empty fields, also at EOL (but not at EOF)
+//  - quoted fields, also with commas and quotes in them
+//  - unterminated last line
+//  - blank line / empty record
+
+func TestCsvTokenizer1(t *testing.T) {
+	text := `a,b=1,cc=2,,e,"f=1,2,3","g,""y"",z",
+
+A,B`
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	checkMatch(t, tokenizer, "a", CsvEqSentinel)
+	checkMatch(t, tokenizer, "b=1", 2)
+	checkMatch(t, tokenizer, "cc=2", 3)
+	checkMatch(t, tokenizer, "", CsvEqSentinel)
+	checkMatch(t, tokenizer, "e", CsvEqSentinel)
+	checkMatch(t, tokenizer, "f=1,2,3", 2)
+	checkMatch(t, tokenizer, "g,\"y\",z", CsvEqSentinel)
+	checkMatch(t, tokenizer, "", CsvEqSentinel)
+	checkSentinel(t, tokenizer, CsvEol)
+	checkSentinel(t, tokenizer, CsvEol)
+	checkMatch(t, tokenizer, "A", CsvEqSentinel)
+	checkMatch(t, tokenizer, "B", CsvEqSentinel)
+	checkSentinel(t, tokenizer, CsvEof)
+}
+
+// This tests:
+//  - empty field at EOF
+
+func TestCsvTokenizer2(t *testing.T) {
+	text := `a,`
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	checkMatch(t, tokenizer, "a", CsvEqSentinel)
+	checkMatch(t, tokenizer, "", CsvEqSentinel)
+	checkSentinel(t, tokenizer, CsvEof)
+}
+
+// This tests:
+//  - syntax error: eol in quoted string
+
+func TestCsvTokenizer3(t *testing.T) {
+	text := `a,"hi
+ho`
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	checkMatch(t, tokenizer, "a", CsvEqSentinel)
+	checkErr(t, tokenizer)
+}
+
+// This tests:
+//  - syntax error: eof in quoted string
+
+func TestCsvTokenizer4(t *testing.T) {
+	text := `a,"hi`
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	checkMatch(t, tokenizer, "a", CsvEqSentinel)
+	checkErr(t, tokenizer)
+}
+
+// This tests:
+//  - syntax error: junk following quoted string
+
+func TestCsvTokenizer5(t *testing.T) {
+	text := `a,"hi"x,y`
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	checkMatch(t, tokenizer, "a", CsvEqSentinel)
+	checkErr(t, tokenizer)
+}
+
+// This tests:
+//  - syntax error: quote in unquoted string
+
+func TestCsvTokenizer6(t *testing.T) {
+	text := `a,hi"x,y`
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	checkMatch(t, tokenizer, "a", CsvEqSentinel)
+	checkErr(t, tokenizer)
+}
+
+// This tests:
+//  - refill logic
+//
+// Basically we're creating an input s.t. the characters for a token overlap the buffer boundary.
+// Parts of the token are read on the initial fill, then the rest on the second fill.  The file
+// contains single-token lines, each line is the 26-character string a...z followed by a newline.
+// The test then just checks that every token looks right.
+
+func TestCsvTokenizer7(t *testing.T) {
+	// Token+newline must straddle the buffer boundary in some interesting way
+	if !(bufferSize%27 != 0 && bufferSize%27 != 1 && bufferSize%27 != 26) {
+		panic("Failed precondition")
+	}
+	text := ""
+	count := bufferSize * 3 / 27
+	for i := 0; i < count; i++ {
+		text += "abcdefghijklmnopqrstuvwxyz\n"
+	}
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	state := 0
+	found := 0
+Loop:
+	for {
+		a, b, c, err := tokenizer.Get()
+		if err != nil {
+			t.Fatal(err)
+		}
+		switch a {
+		case CsvEol:
+			if state != 1 {
+				t.Fatal("Bad state at EOL")
+			}
+			state = 0
+		case CsvEof:
+			if state != 0 {
+				t.Fatal("Bad state at EOF")
+			}
+			break Loop
+		default:
+			if state != 0 {
+				t.Fatal("Bad state at token")
+			}
+			if tokenizer.GetString(a, b) != "abcdefghijklmnopqrstuvwxyz" {
+				t.Fatal("Bad string")
+			}
+			if c != CsvEqSentinel {
+				t.Fatal("Bad sentinel")
+			}
+			state = 1
+			found++
+		}
+	}
+	if found != count {
+		t.Fatal("Did not find the expected count")
+	}
+}
+
+// This tests:
+//  - i/o error on refill
+
+func TestCsvTokenizer8(t *testing.T) {
+	// This is the same input as test_csv_tokenizer7() for a reason, see below.
+	text := ""
+	count := bufferSize * 3 / 27
+	for i := 0; i < count; i++ {
+		text += "abcdefghijklmnopqrstuvwxyz\n"
+	}
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	_, _, _, err := tokenizer.Get() // Fill once
+	if err != nil {
+		panic(err)
+	}
+	tokenizer.SetFailRefill()
+	for {
+		a, _, _, err := tokenizer.Get()
+		if err != nil {
+			// This can only be an I/O error because TestCsvTokenizer7() would otherwise have
+			// encountered it, since it uses the same input.
+			break
+		}
+		if a == CsvEof {
+			t.Fatal("EOF")
+		}
+	}
+}
+
+func checkMatchTag(t *testing.T, tokenizer *CsvTokenizer, tag, s string) {
+	a, b, c, err := tokenizer.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a < 0 {
+		t.Fatalf("Unexpected start value %d", a)
+	}
+	if c == CsvEqSentinel {
+		t.Fatal("Expected eqloc")
+	}
+	if !tokenizer.MatchTag(tag, a, c) {
+		t.Fatal("MatchTag should succeed")
+	}
+	if tokenizer.MatchTag("nih", a, c) {
+		t.Fatal("MatchTag should fail")
+	}
+	s2 := tokenizer.GetString(c, b)
+	if s2 != s {
+		t.Fatalf("Not a match for value '%s': '%s'", s, s2)
+	}
+}
+
+// Test the MatchTag method
+
+func TestCsvTokenizer9(t *testing.T) {
+	text := `a=10,baba=20,cc=2,dd=`
+	tokenizer := NewTokenizer(bytes.NewReader([]byte(text)))
+	checkMatchTag(t, tokenizer, "a", "10")
+	checkMatchTag(t, tokenizer, "baba", "20")
+	checkMatchTag(t, tokenizer, "cc", "2")
+	checkMatchTag(t, tokenizer, "dd", "")
+	checkSentinel(t, tokenizer, CsvEof)
+}
+

--- a/code/go-utils/sonarlog/csvtokens_test.go
+++ b/code/go-utils/sonarlog/csvtokens_test.go
@@ -239,4 +239,3 @@ func TestCsvTokenizer9(t *testing.T) {
 	checkMatchTag(t, tokenizer, "dd", "")
 	checkSentinel(t, tokenizer, CsvEof)
 }
-

--- a/code/go-utils/sonarlog/gpulist.go
+++ b/code/go-utils/sonarlog/gpulist.go
@@ -14,7 +14,7 @@ import (
 //
 // There will be *a lot* of these both in input and in memory, so:
 // - representation compactness is important
-// - avoiding pointers in the representation is important (or SonarReading will have pointers too)
+// - avoiding pointers in the representation is important (or Sample will have pointers too)
 // - avoiding a lot of garbage generation during parsing is important
 
 type GpuSet uint32

--- a/code/go-utils/sonarlog/logstore.go
+++ b/code/go-utils/sonarlog/logstore.go
@@ -1,0 +1,125 @@
+package sonarlog
+
+import (
+	"os"
+	"path"
+	"runtime"
+	"time"
+
+	"go-utils/filesys"
+	"go-utils/hostglob"
+)
+
+type LogStore struct {
+	dataDir string
+}
+
+// `dir` is the root directory of the log data store for a cluster.  It contains subdirectory paths
+// of the form YYYY/MM/DD for data.  At the leaf of each path are read-only data files for the given
+// date:
+//
+//  - HOSTNAME.csv contain Sonar `ps` log data for the given host
+//  - sysinfo-HOSTNAME.json contain Sonar `sysinfo` system data for the given host
+
+func OpenDir(dir string) (*LogStore, error) {
+	return &LogStore{dataDir: dir}, nil
+}
+
+// In sonalyze, the source and record filters have these options:
+//
+// - from/to
+// - host include, default all
+// - user include/exclude
+// - command include/exclude
+// - job ID include/exclude
+//
+// The dates and the host can be applied at the file system level under reasonable assumptions.  The
+// others require the record to be read and parsed.
+//
+// One design point here is about the recordFilter.  We must choose whether it must be thread-safe
+// and can be applied in parallel while the result list is being constructed, or whether it need not
+// be thread-safe and is applied in the master thread.  Probably the latter is better?
+//
+// A very discriminating recordFilter suggests that records should be allocated singly on the heap,
+// not inside a larger slice.
+//
+// The recordFilter is necessarily primitive: it is *not* a job filter (though the Job ID is a
+// thing) and not all fields of the record will make sense unless the record has been rectified
+// first.  So we need to be clear about which fields the recordFilter can examine.
+
+func (s *LogStore) LogEntries(
+	fromDate, toDate time.Time,
+	hosts *hostglob.HostGlobber,
+	recordFilter func(*SonarReading) bool,
+	verbose bool,
+) (readings []*SonarReading, heartbeats []*SonarHeartbeat, dropped int, err error) {
+	files, err := filesys.EnumerateFiles(s.dataDir, fromDate, toDate, "*.csv")
+	if err != nil {
+		return
+	}
+	if hosts != nil {
+		dest := 0
+		for src := 0; src < len(files); src++ {
+			fn := files[src]
+			if hosts.Match(fn[:len(fn)-4]) {
+				files[dest] = files[src]
+				dest++
+			}
+		}
+		files = files[:dest]
+	}
+	if verbose {
+		println(len(files), " files")
+	}
+	pendingFiles := make(chan string, len(files))
+	type resultrec struct {
+		rs []*SonarReading
+		hs []*SonarHeartbeat
+		dr int
+	}
+	results := make(chan *resultrec, len(files))
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go (func() {
+			uf := NewUstrCache()
+			for {
+				fn := <-pendingFiles
+				res := new(resultrec)
+				inputFile, err := os.Open(fn)
+				if err == nil {
+					readings, heartbeats, badRecords, err := ParseSonarLog(inputFile, uf)
+					if err == nil {
+						res.rs = readings
+						res.hs = heartbeats
+						res.dr = badRecords
+					}
+					inputFile.Close()
+				}
+				results <- res
+			}
+		})()
+	}
+
+	readings = make([]*SonarReading, 0)
+	heartbeats = make([]*SonarHeartbeat, 0)
+
+	// TODO: Merge these loops using select, then reduce the sizes of the channels.
+
+	for _, fn := range files {
+		pendingFiles <- path.Join(s.dataDir, fn)
+	}
+
+	// TODO: If recordFilter is not nil, it needs to be applied somewhow.
+
+	for _, _ = range files {
+		res := <-results
+		readings = append(readings, res.rs...)
+		heartbeats = append(heartbeats, res.hs...)
+		dropped += res.dr
+	}
+
+	// TODO: there's still some basic cleanup of data (a la logclean) to do probably
+
+	// TODO: make sure the goroutines exit, they are holding onto resources
+
+	return
+}

--- a/code/go-utils/sonarlog/postprocess.go
+++ b/code/go-utils/sonarlog/postprocess.go
@@ -41,9 +41,9 @@ type InputStreamSet map[InputStreamKey]*SampleStream
 //   gpumem_pct and gpumem_gb fields so that they are internally consistent
 // - after all that, remove records for which the filter function returns false
 //
-// Returns the individual streams as a map from (hostname, id, cmd) to a vector of LogEntries,
-// where each vector is sorted in ascending order of time.  In each vector, there may be no
-// adjacent records with the same timestamp.
+// Returns the individual streams as a map from (hostname, id, cmd) to a vector of Samples, where
+// each vector is sorted in ascending order of time.  In each vector, there may be no adjacent
+// records with the same timestamp.
 //
 // The id is necessary to distinguish the different event streams for a single job.  Consider a run
 // of records from the same host.  There may be multiple records per job in that run, and they may
@@ -67,7 +67,7 @@ type InputStreamSet map[InputStreamKey]*SampleStream
 
 const JobIdTag = 10000000
 
-type TimeSortableReadings []*SonarReading
+type TimeSortableReadings SampleStream
 
 func (t TimeSortableReadings) Len() int { return len(t) }
 func (t TimeSortableReadings) Less(i, j int) bool {
@@ -79,7 +79,7 @@ func (t TimeSortableReadings) Swap(i, j int) {
 
 func PostprocessLog(
 	entries SampleStream,
-	filter func(*SonarReading) bool,
+	filter func(*Sample) bool,
 	configs *config.ClusterConfig,
 ) InputStreamSet {
 	streams := make(InputStreamSet)
@@ -96,8 +96,7 @@ func PostprocessLog(
 		if stream, found := streams[key]; found {
 			*stream = append(*stream, e)
 		} else {
-			ss := SampleStream([]*SonarReading{e})
-			streams[key] = &ss
+			streams[key] = &SampleStream{e}
 		}
 	}
 

--- a/code/go-utils/sonarlog/postprocess.go
+++ b/code/go-utils/sonarlog/postprocess.go
@@ -1,0 +1,228 @@
+// Postprocess and clean up log data after ingestion.
+
+package sonarlog
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+
+	"go-utils/config"
+)
+
+// The InputStreamKey is (hostname, stream-id, cmd), where the stream-id is defined below; it is
+// meaningful only for non-merged streams.
+//
+// An InputStreamSet maps a InputStreamKey to a SampleStream pertinent to that key.  It is named as
+// it is because the InputStreamKey is meaningful only for non-merged streams.
+
+type InputStreamKey struct {
+	Host     Ustr
+	StreamId uint32
+	Cmd      Ustr
+}
+
+// The streams are heap-allocated so that we can update them without also updating the map.
+//
+// After postprocessing, there are some important invariants on the records that make up an input
+// stream in addition to them having the same key:
+//
+// - the vector is sorted ascending by timestamp
+// - no two adjacent timestamps are the same
+
+type InputStreamSet map[InputStreamKey]*SampleStream
+
+// Apply postprocessing to the records in the array:
+//
+// - reconstruct individual sample streams
+// - compute the cpu_util_pct field from cputime_sec and timestamp for consecutive records in
+//   streams
+// - if `configs` is not None and there is the necessary information for a given host, clean up the
+//   gpumem_pct and gpumem_gb fields so that they are internally consistent
+// - after all that, remove records for which the filter function returns false
+//
+// Returns the individual streams as a map from (hostname, id, cmd) to a vector of LogEntries,
+// where each vector is sorted in ascending order of time.  In each vector, there may be no
+// adjacent records with the same timestamp.
+//
+// The id is necessary to distinguish the different event streams for a single job.  Consider a run
+// of records from the same host.  There may be multiple records per job in that run, and they may
+// or may not also have the same cmd, and they may or may not have been rolled up.  There are two
+// cases:
+//
+// - If the job is not rolled-up then we know that for a given pid there is only ever one record at
+//   a given time.
+//
+// - If the job is rolled-up then we know that for a given (job_id, cmd) pair there is only one
+//   record, but job_id by itself is not enough to distinguish records, and there is no obvious
+//   distinguishing pid value, as the set of rolled-up processes may change from invocation to
+//   invocation of sonar.  We also know a rolled-up record has rolledup > 0.
+//
+// Therefore, let the pid for a rolled-up record r be JOB_ID_TAG + r.job_id.  Then (pid, cmd) is
+// enough to distinguish a record always, though it is more complicated than necessary for
+// non-rolled-up jobs.
+//
+// TODO: JobIdTag is currently 1e8 because Linux pids are smaller than 1e8, so this guarantees that
+// there is not a clash with a pid, but it's possible job IDs can be larger than PIDS.
+
+const JobIdTag = 10000000
+
+type TimeSortableReadings []*SonarReading
+
+func (t TimeSortableReadings) Len() int { return len(t) }
+func (t TimeSortableReadings) Less(i, j int) bool {
+	return t[i].Timestamp < t[j].Timestamp
+}
+func (t TimeSortableReadings) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+func PostprocessLog(
+	entries SampleStream,
+	filter func(*SonarReading) bool,
+	configs *config.ClusterConfig,
+) InputStreamSet {
+	streams := make(InputStreamSet)
+
+	// Reconstruct the individual sample streams.  Records for job id 0 are always not rolled up and
+	// we'll use the pid, which is unique.  But consumers of the data must be sure to treat job id 0
+	// specially.
+	for _, e := range entries {
+		syntheticPid := e.Pid
+		if e.Rolledup > 0 {
+			syntheticPid = JobIdTag + e.Job
+		}
+		key := InputStreamKey{e.Host, syntheticPid, e.Cmd}
+		if stream, found := streams[key]; found {
+			*stream = append(*stream, e)
+		} else {
+			ss := SampleStream([]*SonarReading{e})
+			streams[key] = &ss
+		}
+	}
+
+	// Sort the streams by ascending timestamp.
+	for _, stream := range streams {
+		sort.Sort(TimeSortableReadings(*stream))
+	}
+
+	// Remove duplicate timestamps.  These may appear due to system effects, notably, sonar log
+	// generation may be delayed due to disk waits, which may be long because network disks may
+	// go away.  It should not matter which of the duplicate records we remove here, they should
+	// be identical.
+	for _, stream := range streams {
+		good := 0
+		candidate := good + 1
+		es := *stream
+		for candidate < len(es) {
+			for candidate < len(es) && es[good].Timestamp == es[candidate].Timestamp {
+				candidate++
+			}
+			if candidate < len(es) {
+				good++
+				es[good], es[candidate] = es[candidate], es[good]
+				candidate++
+			}
+		}
+		*stream = es[:good+1]
+	}
+
+	// For each stream, compute the cpu_util_pct field of each record.
+	//
+	// For v0.7.0 and later, compute this as the difference in cputime_sec between adjacent records
+	// divided by the time difference between them.  The first record gets a copy of the cpu_pct
+	// field.
+	//
+	// For v0.6.0 and earlier, we don't have cputime_sec.  The best we can do with the data we have
+	// is copy the cpu_pct field into cpu_util_pct.
+	for _, stream := range streams {
+		// By construction, every stream is non-empty.
+		es := *stream
+		es[0].CpuUtilPct = es[0].CpuPct
+		major, minor, _ := parseVersion(es[0].Version)
+		if major == 0 && minor <= 6 {
+			for i := 1; i < len(es); i++ {
+				es[i].CpuUtilPct = es[i].CpuPct
+			}
+		} else {
+			for i := 1; i < len(es); i++ {
+				dt := float64(es[i].Timestamp - es[i-1].Timestamp)
+				dc := float64(es[i].CpuTimeSec - es[i-1].CpuTimeSec)
+				// It can happen that dc < 0, see https://github.com/NAICNO/Jobanalyzer/issues/63.
+				// We filter these below.
+				es[i].CpuUtilPct = float32((dc / dt) * 100)
+			}
+		}
+	}
+
+	// For each stream, clean up the gpumem_pct and gpumem_gb fields based on system information, if
+	// available.
+	if configs != nil {
+		for _, stream := range streams {
+			if conf := configs.LookupHost((*stream)[0].Host.String()); conf != nil {
+				cardsizeKib := float64(conf.GpuMemGB) * 1024 * 1024 / float64(conf.GpuCards)
+				for _, entry := range *stream {
+					if conf.GpuMemPct {
+						entry.GpuKib = uint64(float64(entry.GpuMemPct) * cardsizeKib)
+					} else {
+						entry.GpuMemPct = float32(float64(entry.GpuKib) / cardsizeKib)
+					}
+				}
+			}
+		}
+	}
+
+	// Remove elements that don't pass the filter and pack the array.  This preserves ordering.
+	for _, stream := range streams {
+		dst := 0
+		es := *stream
+		for src := range es {
+			// See comments above re the test for cpu_util_pct
+			if filter(es[src]) && es[src].CpuUtilPct >= 0 {
+				es[dst], es[src] = es[src], es[dst]
+				dst++
+			}
+		}
+		*stream = es[:dst]
+	}
+
+	// Some streams may now be empty; remove them.
+	dead := make([]InputStreamKey, 0)
+	for key, stream := range streams {
+		if len(*stream) == 0 {
+			dead = append(dead, key)
+		}
+	}
+	for _, key := range dead {
+		delete(streams, key)
+	}
+
+	return streams
+}
+
+func parseVersion(v Ustr) (major, minor, bugfix int) {
+	smajor, s1, found := strings.Cut(v.String(), ".")
+	if !found {
+		return
+	}
+	sminor, sbugfix, found := strings.Cut(s1, ".")
+	if !found {
+		return
+	}
+	tmp, err := strconv.Atoi(smajor)
+	if err != nil {
+		return
+	}
+	major = tmp
+	tmp, err = strconv.Atoi(sminor)
+	if err != nil {
+		return
+	}
+	minor = tmp
+	tmp, err = strconv.Atoi(sbugfix)
+	if err != nil {
+		return
+	}
+	bugfix = tmp
+	return
+}

--- a/code/go-utils/sonarlog/postprocess_test.go
+++ b/code/go-utils/sonarlog/postprocess_test.go
@@ -1,0 +1,122 @@
+package sonarlog
+
+import (
+	"os"
+	"testing"
+)
+
+func TestPostprocessLogCpuUtilPct(t *testing.T) {
+	// This file has field names, cputime_sec, pid, and rolledup.  There are two hosts.  One of the
+	// records is invalid: it's missing the user name.  Another record has a field with an unknown
+	// tag.  Both are counted together as "discarded" which is sort of nuts.
+	f, err := os.Open("../../tests/sonarlog/whitebox-logclean.csv")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, _, discarded, err := ParseSonarLog(f, NewUstrFacade())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 7 {
+		t.Fatalf("Expected 7, got %d", len(entries))
+	}
+	if discarded != 2 {
+		t.Fatalf("Expected 2 discarded, got %d", discarded)
+	}
+
+	root := StringToUstr("root")
+	streams := PostprocessLog(entries, func(r *SonarReading) bool { return r.User != root }, nil)
+
+	if len(streams) != 4 {
+		t.Fatalf("Expected 4 streams, got %d", len(streams))
+	}
+	s1, found := streams[InputStreamKey{
+		StringToUstr("ml4.hpc.uio.no"),
+		JobIdTag + 4093,
+		StringToUstr("zabbix_agentd"),
+	}]
+	if !found {
+		t.Fatalf("No entry s1")
+	}
+	if len(*s1) != 1 {
+		t.Fatalf("Expected one element in stream s1")
+	}
+
+	s2, found := streams[InputStreamKey{
+		StringToUstr("ml4.hpc.uio.no"),
+		1090,
+		StringToUstr("python"),
+	}]
+	if !found {
+		t.Fatalf("No entry s2")
+	}
+	if len(*s2) != 3 {
+		t.Fatalf("Expected three elements in stream s2")
+	}
+	if (*s2)[0].Timestamp >= (*s2)[1].Timestamp {
+		t.Fatal("Timestamp 0")
+	}
+	if (*s2)[1].Timestamp >= (*s2)[2].Timestamp {
+		t.Fatal("Timestamp 1")
+	}
+
+	// For this pid (1090) there are three records for ml4, pairwise 300 seconds apart (and
+	// disordered in the input), and the cputime_sec field for the second record is 300 seconds
+	// higher, giving us 100% utilization for that time window, and for the third record 150 seconds
+	// higher, giving us 50% utilization for that window.
+
+	if (*s2)[0].CpuUtilPct != 1473.7 {
+		t.Fatal("Util s2 0")
+	}
+	if (*s2)[1].CpuUtilPct != 100.0 {
+		t.Fatal("Util s2 1")
+	}
+	if (*s2)[2].CpuUtilPct != 50.0 {
+		t.Fatal("Util s2 2")
+	}
+
+	// This has the same pid *but* a different host, so the utilization for the first record should
+	// once again be set to the cpu_pct value.
+
+	s3, found := streams[InputStreamKey{
+		StringToUstr("ml5.hpc.uio.no"),
+		1090,
+		StringToUstr("python"),
+	}]
+	if !found {
+		t.Fatalf("No entry s3")
+	}
+	if len(*s3) != 1 {
+		t.Fatalf("Expected three elements in stream s3")
+	}
+	if (*s3)[0].CpuUtilPct != 128.0 {
+		t.Fatal("Util s3 0")
+	}
+
+	s4, found := streams[InputStreamKey{
+		StringToUstr("ml4.hpc.uio.no"),
+		1089,
+		StringToUstr("python"),
+	}]
+	if !found {
+		t.Fatalf("No entry s4")
+	}
+	if len(*s4) != 1 {
+		t.Fatalf("Expected three elements in stream s4")
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	a, b, c := parseVersion(StringToUstr("1.2.3"))
+	if a != 1 || b != 2 || c != 3 {
+		t.Fatal("Could not parse version")
+	}
+	a, b, c = parseVersion(StringToUstr("1.2"))
+	if a != 0 || b != 0 || c != 0 {
+		t.Fatal("Incorrectly parsed version")
+	}
+	a, b, c = parseVersion(StringToUstr("x.y.z"))
+	if a != 0 || b != 0 || c != 0 {
+		t.Fatal("Incorrectly parsed version")
+	}
+}

--- a/code/go-utils/sonarlog/postprocess_test.go
+++ b/code/go-utils/sonarlog/postprocess_test.go
@@ -13,7 +13,7 @@ func TestPostprocessLogCpuUtilPct(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	entries, _, discarded, err := ParseSonarLog(f, NewUstrFacade())
+	entries, discarded, err := ParseSonarLog(f, NewUstrFacade())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func TestPostprocessLogCpuUtilPct(t *testing.T) {
 	}
 
 	root := StringToUstr("root")
-	streams := PostprocessLog(entries, func(r *SonarReading) bool { return r.User != root }, nil)
+	streams := PostprocessLog(entries, func(r *Sample) bool { return r.User != root }, nil)
 
 	if len(streams) != 4 {
 		t.Fatalf("Expected 4 streams, got %d", len(streams))

--- a/code/go-utils/sonarlog/types.go
+++ b/code/go-utils/sonarlog/types.go
@@ -43,6 +43,7 @@ type SonarReading struct {
 	CpuPct      float32
 	Gpus        GpuSet
 	GpuPct      float32
+	CpuUtilPct  float32
 	GpuMemPct   float32
 	Rolledup    uint32
 	GpuFail     uint8
@@ -54,3 +55,13 @@ type SonarHeartbeat struct {
 	Cluster   Ustr
 	Host      Ustr
 }
+
+// A sample stream is just a list of samples.
+
+type SampleStream []*SonarReading
+
+// A bag of streams.  The constraints on the individual streams in terms of uniqueness and so on
+// depends on how they were merged and are not implied by the type.
+
+type SampleStreams []*SampleStream
+

--- a/code/go-utils/sonarlog/types.go
+++ b/code/go-utils/sonarlog/types.go
@@ -21,12 +21,16 @@ package sonarlog
 //  - There are many fields that have unused bits, for example, Ustr is unlikely ever to need
 //    more than 24 bits, most memory sizes need more than 32 bits but not more than 38, Job and
 //    Process IDs are probably 24 bits or so, and Rolledup is unlikely to be more than 16 bits.
-//    GpuFail is a single bit at present.
+//    GpuFail and Flags are single bits at present.
 //
 // It seems likely that if we applied all of these we could save another 30 bytes easily.
 
-type SonarReading struct {
-	Timestamp   int64 // seconds since year 1
+const (
+	FlagHeartbeat = 1 // Record is a heartbeat record
+)
+
+type Sample struct {
+	Timestamp   int64
 	MemtotalKib uint64
 	CpuKib      uint64
 	RssAnonKib  uint64
@@ -47,21 +51,14 @@ type SonarReading struct {
 	GpuMemPct   float32
 	Rolledup    uint32
 	GpuFail     uint8
-}
-
-type SonarHeartbeat struct {
-	Timestamp int64 // seconds since year 1
-	Version   Ustr
-	Cluster   Ustr
-	Host      Ustr
+	Flags       uint8
 }
 
 // A sample stream is just a list of samples.
 
-type SampleStream []*SonarReading
+type SampleStream []*Sample
 
 // A bag of streams.  The constraints on the individual streams in terms of uniqueness and so on
 // depends on how they were merged and are not implied by the type.
 
 type SampleStreams []*SampleStream
-

--- a/code/go-utils/sonarlog/ustr.go
+++ b/code/go-utils/sonarlog/ustr.go
@@ -188,8 +188,9 @@ func (uf *UstrFacade) AllocBytes(bs []byte) Ustr {
 // node carries the name and the Ustr value of that name.
 
 const (
-	inverseLoad uint32 = 3
-	initialCapacity uint32 = 100
+	// These matter.  L=10 is pretty aggressive.
+	inverseLoad uint32 = 10
+	initialCapacity uint32 = 93
 )
 
 type hashtable struct {
@@ -290,7 +291,7 @@ type hashcode uint32
 func hashString(s string) hashcode {
 	h := uint32(0)
 	for i := range s {
-		h = (h << 3) ^ uint32(s[i])
+		h = (h << 4) + uint32(s[i]) + (h >> 28)
 	}
 	return hashcode(h)
 }
@@ -298,7 +299,7 @@ func hashString(s string) hashcode {
 func hashBytes(bs []byte) hashcode {
 	h := uint32(0)
 	for _, c := range bs {
-		h = (h << 3) ^ uint32(c)
+		h = (h << 4) + uint32(c) + (h >> 28)
 	}
 	return hashcode(h)
 }

--- a/code/sandbox/.gitignore
+++ b/code/sandbox/.gitignore
@@ -1,0 +1,2 @@
+gsonarlog
+*.prof

--- a/code/sandbox/go.mod
+++ b/code/sandbox/go.mod
@@ -1,0 +1,6 @@
+module gsonarlog
+
+go 1.20
+
+require go-utils v0.0.0-00010101000000-000000000000
+replace go-utils => ../go-utils

--- a/code/sandbox/gsonarlog.go
+++ b/code/sandbox/gsonarlog.go
@@ -78,12 +78,12 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	readings, heartbeats, dropped, err := log.LogEntries(fromDate, toDate, nil, nil, verbose)
+	readings, dropped, err := log.LogEntries(fromDate, toDate, nil, nil, verbose)
 	if err != nil {
 		panic(err)
 	}
 	if verbose {
-		fmt.Printf("%d records, %d heartbeats, %d dropped\n", len(readings), len(heartbeats), dropped)
-		sonarlog.UstrStats()
+		fmt.Printf("%d records, %d dropped\n", len(readings), dropped)
+		sonarlog.UstrStats(false)
 	}
 }

--- a/code/sandbox/gsonarlog.go
+++ b/code/sandbox/gsonarlog.go
@@ -1,0 +1,89 @@
+// This is test code for perf testing.  It corresponds in some ways to `sonalyze parse`.
+//
+// Usage:
+//   gsonarlog -data-dir dir [-from date] [-to date] [-cpuprofile filename]
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go-utils/sonarlog"
+	gut "go-utils/time"
+	"os"
+	"path"
+	"runtime/pprof"
+	"time"
+	"unsafe"
+)
+
+var (
+	dataDir  string
+	fromDate time.Time
+	toDate   time.Time
+	cpuProfile string
+	verbose bool
+)
+
+func main() {
+	flag.StringVar(&dataDir, "data-dir", "", "Root `directory` of data store")
+	var fromDateStr, toDateStr string
+	flag.StringVar(&fromDateStr, "from", "",
+		"Earliest `date` to include, YYYY-MM-DD or Nd or Nw, default 1d")
+	flag.StringVar(&toDateStr, "to", "",
+		"Latest `date` to include, YYYY-MM-DD or Nd or Nw, default today")
+	flag.StringVar(&cpuProfile, "cpuprofile", "", "write cpu profile to `filename`")
+	flag.BoolVar(&verbose, "v", false, "debug info")
+	flag.Parse()
+
+	if dataDir == "" {
+		panic("Required: -data-dir")
+	}
+	dataDir = path.Clean(dataDir)
+	if fromDateStr != "" {
+		var err error
+		fromDate, err = gut.ParseRelativeDate(fromDateStr)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		fromDate = time.Now().UTC().AddDate(0, 0, -1)
+	}
+	fromDate = gut.ThisDay(fromDate)
+
+	if toDateStr != "" {
+		var err error
+		toDate, err = gut.ParseRelativeDate(toDateStr)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		toDate = time.Now().UTC()
+	}
+	toDate = gut.NextDay(toDate)
+
+	if cpuProfile != "" {
+		f, err := os.Create(cpuProfile)
+		if err != nil {
+			panic(err)
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
+	if verbose {
+		fmt.Printf("Size of SonarReading: %d\n", unsafe.Sizeof(sonarlog.SonarReading{}))
+	}
+	log, err := sonarlog.OpenDir(dataDir)
+	if err != nil {
+		panic(err)
+	}
+	readings, heartbeats, dropped, err := log.LogEntries(fromDate, toDate, nil, nil, verbose)
+	if err != nil {
+		panic(err)
+	}
+	if verbose {
+		fmt.Printf("%d records, %d heartbeats, %d dropped\n", len(readings), len(heartbeats), dropped)
+		sonarlog.UstrStats()
+	}
+}

--- a/code/sandbox/gsonarlog.go
+++ b/code/sandbox/gsonarlog.go
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	if verbose {
-		fmt.Printf("Size of SonarReading: %d\n", unsafe.Sizeof(sonarlog.SonarReading{}))
+		fmt.Printf("Size of Sample: %d\n", unsafe.Sizeof(sonarlog.Sample{}))
 	}
 	log, err := sonarlog.OpenDir(dataDir)
 	if err != nil {

--- a/code/sonarlog/src/logclean.rs
+++ b/code/sonarlog/src/logclean.rs
@@ -128,6 +128,7 @@ where
         let (major, minor) = (stream[0].major, stream[0].minor);
         if major == 0 && minor <= 6 {
             for i in 1..stream.len() {
+                // FIXME: This looks buggy
                 stream[i].cpu_util_pct = stream[0].cpu_pct;
             }
         } else {


### PR DESCRIPTION
These are various performance experiments sitting on top of the patch for #452, and a test driver for the whole stack.  By using a custom hash table and some custom parsers to avoid allocations during csv parsing we reduce parsing time significantly without increasing memory use.  The complexity cost is moderate-ish -- hash tables are fickle beasts, and more can be done to tune this one, it uses too much memory now (10% occupancy) and the hash function is home-grown.

I'm making this a PR mostly to surface it and to have a place to keep comments and ideas.