### PR TITLE
#529 - Fixing the issue of hosts are not sorted in the dashboard as intended. 

### DIFF
--- a/code/dashboard-2/package.json
+++ b/code/dashboard-2/package.json
@@ -50,5 +50,6 @@
     "typescript": "^5.2.2",
     "vite": "^5.2.8",
     "vitest": "^1.5.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/code/dashboard-2/src/hooks/useFetchDashboard.ts
+++ b/code/dashboard-2/src/hooks/useFetchDashboard.ts
@@ -4,6 +4,7 @@ import { AxiosInstance } from 'axios'
 import useAxios from './useAxios.ts'
 import { QueryKeys } from '../Constants.ts'
 import { makeFilter } from '../util/query/QueryUtils.ts'
+import { sortDashboardTableRows } from '../util/TableUtils.ts'
 
 const fetchDashboard = async (axios: AxiosInstance, clusterName: string) => {
   const endpoint = `/${clusterName}-at-a-glance.json`
@@ -11,8 +12,9 @@ const fetchDashboard = async (axios: AxiosInstance, clusterName: string) => {
   return response.data
 }
 
-export const useFetchDashboard = (clusterName: string, query: string) => {
+export const useFetchDashboard = (cluster: Cluster, query: string) => {
   const axios = useAxios()
+  const clusterName = cluster.cluster
   return useQuery(
     {
       queryKey: [QueryKeys.DASHBOARD_TABLE, clusterName],
@@ -20,6 +22,8 @@ export const useFetchDashboard = (clusterName: string, query: string) => {
       select: data => {
         const filter = makeFilter(query)
         const filtered = data.filter(filter)
+        filtered.sort((a: DashboardTableItem, b: DashboardTableItem) => sortDashboardTableRows(a, b, cluster.uptime))
+
         return filtered.map((item: Partial<DashboardTableItem>) => {
           return {
             ...item,

--- a/code/dashboard-2/src/pages/DashboardPage.tsx
+++ b/code/dashboard-2/src/pages/DashboardPage.tsx
@@ -44,7 +44,7 @@ export default function DashboardPage() {
     setQuery(defaultQuery)
   }, [selectedCluster])
 
-  const {data, isFetched} = useFetchDashboard(clusterName!, query)
+  const {data, isFetched} = useFetchDashboard(selectedCluster, query)
 
   const [sorting, setSorting] = useState<SortingState>([])
 

--- a/code/dashboard-2/src/util/TableUtils.ts
+++ b/code/dashboard-2/src/util/TableUtils.ts
@@ -266,3 +266,25 @@ export const sortByDuration: SortingFn<JobQueryResultsTableItem> = (rowA, rowB, 
   }
   return 0
 }
+
+// failing cpus are sorted higher
+// failing gpus are sorted higher
+// then non-failing systems
+// within each group, by hostname
+export const sortDashboardTableRows = (a: DashboardTableItem, b: DashboardTableItem, uptime: boolean) => {
+  if (uptime) {
+    if (a.cpu_status != b.cpu_status) {
+      return b.cpu_status - a.cpu_status
+    }
+    if (a.gpu_status != b.gpu_status) {
+      return b.gpu_status - a.gpu_status
+    }
+  }
+  if (a.hostname < b.hostname) {
+    return -1
+  }
+  if (a.hostname > b.hostname) {
+    return 1
+  }
+  return 0
+}


### PR DESCRIPTION
**Sort order**

Failing cpus are sorted higher
Failing gpus are sorted higher
Then non-failing systems within each group, by hostname