### PR TITLE
Fix #561 - profile resident memory, not virtual

### DIFF
--- a/code/dashboard-2/src/Constants.ts
+++ b/code/dashboard-2/src/Constants.ts
@@ -40,7 +40,7 @@ export const DURATION_REGEX = /^(.*)d(.*)h(.*)m$/
 
 export const PROFILE_NAMES = [
   {key: 'cpu', text: 'CPU'},
-  {key: 'mem', text: 'RAM'},
+  {key: 'res', text: 'RAM'},
   {key: 'gpu', text: 'GPU'},
   {key: 'gpumem', text: 'GPU RAM'}
 ]

--- a/code/dashboard/jobquery.js
+++ b/code/dashboard/jobquery.js
@@ -300,7 +300,7 @@ function recomputeURLs() {
 
 // Pick up parameters and create a new window with the selected profile
 
-var profnames = ["cpu", "mem", "gpu", "gpumem"]
+var profnames = ["cpu", "res", "gpu", "gpumem"]
 
 function makeProfileURL(cluster, from, to, row) {
     // About adding "host" here always:


### PR DESCRIPTION
Just change the key in both dashboards.  I have confidence in this change in the old dashboard :-), in the new it's mostly a guess.