### PR TITLE
For #526 - move filtering earlier

### DIFF
--- a/code/sonalyze/analysis.go
+++ b/code/sonalyze/analysis.go
@@ -47,6 +47,7 @@ func localAnalysis(cmd SampleAnalysisCommand, _ io.Reader, stdout, stderr io.Wri
 			args.FromDate,
 			args.ToDate,
 			hostGlobber,
+			recordFilter,
 			args.Verbose,
 		)
 	if err != nil {
@@ -57,7 +58,7 @@ func localAnalysis(cmd SampleAnalysisCommand, _ io.Reader, stdout, stderr io.Wri
 		UstrStats(stderr, false)
 	}
 
-	sonarlog.ComputeAndFilter(streams, recordFilter)
+	sonarlog.ComputePerSampleFields(streams)
 	err = cmd.Perform(stdout, cfg, theLog, streams, bounds, hostGlobber, recordFilter)
 
 	if err != nil {

--- a/code/sonalyze/command/command.go
+++ b/code/sonalyze/command/command.go
@@ -86,7 +86,7 @@ type SampleAnalysisCommand interface {
 		streams sonarlog.InputStreamSet,
 		bounds sonarlog.Timebounds,
 		hostGlobber *hostglob.HostGlobber,
-		recordFilter func(*sonarlog.Sample) bool,
+		recordFilter db.SampleFilter,
 	) error
 
 	// Retrieve configfile for those commands that allow it, otherwise "", or "" for absent

--- a/code/sonalyze/db/samples.go
+++ b/code/sonalyze/db/samples.go
@@ -16,6 +16,10 @@ import (
 // The db.SampleFilter will be applied to individual records and must return true for records to be
 // included and false for all others.
 //
+// The db.SampleFilter is never nil.  (Nil would be meaningful in some corner cases but generally it
+// will almost never be nil in practical situations and remembering the extra nil check is just
+// annoying.)
+//
 // HARD REQUIREMENT: The SampleFilter *must* be thread-safe and *should* be non-locking and
 // non-contending; if it refers to shared resources then the resources should be
 // shared-read-without-locking by all threads.  The filter can be applied at any point in the

--- a/code/sonalyze/db/samples.go
+++ b/code/sonalyze/db/samples.go
@@ -13,6 +13,33 @@ import (
 	. "sonalyze/common"
 )
 
+// The db.SampleFilter will be applied to individual records and must return true for records to be
+// included and false for all others.
+//
+// HARD REQUIREMENT: The SampleFilter *must* be thread-safe and *should* be non-locking and
+// non-contending; if it refers to shared resources then the resources should be
+// shared-read-without-locking by all threads.  The filter can be applied at any point in the
+// ingestion pipeline.
+//
+// Notes:
+//
+// - Go maps are safe for concurrent read access without locking and can be used by the SampleFilter
+//   with that restriction.  From https://go.dev/doc/faq#atomic_maps:
+//
+//     Map access is unsafe only when updates are occurring. As long as all goroutines are only
+//     reading—looking up elements in the map, including iterating through it using a for range
+//     loop—and not changing the map by assigning to elements or doing deletions, it is safe for
+//     them to access the map concurrently without synchronization.
+//
+//   Almost certainly, the program must be careful to establish a happens-before relationship
+//   between map initialization and all map reads for this to be true.  Since the map will likely be
+//   broadcast to a bunch of goroutines this will often happen as a matter of course.
+//
+// - Sonalyze hostglobbers are thread-safe (but not always contention-free due to shared state in
+//   the regex engine, impact TBD.)
+
+type SampleFilter func (*Sample) bool
+
 // Read a stream of Sonar data records, parse them and return them in order.  Returns the number of
 // benign errors, and non-nil error if non-benign error.
 //

--- a/code/sonalyze/jobs/jobs.go
+++ b/code/sonalyze/jobs/jobs.go
@@ -254,6 +254,8 @@ type JobsCommand struct /* implements SampleAnalysisCommand */ {
 	minRuntimeStr string
 }
 
+var _ SampleAnalysisCommand = (*JobsCommand)(nil)
+
 func (_ *JobsCommand) Summary() []string {
 	return []string{
 		"Select jobs by various criteria and present aggregate information",

--- a/code/sonalyze/jobs/perform.go
+++ b/code/sonalyze/jobs/perform.go
@@ -86,7 +86,7 @@ func (jc *JobsCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds,
 	hostGlobber *hostglob.HostGlobber,
-	_ func(*sonarlog.Sample) bool,
+	_ db.SampleFilter,
 ) error {
 	if jc.Verbose {
 		Log.Infof("Streams constructed by postprocessing: %d", len(streams))

--- a/code/sonalyze/load/load.go
+++ b/code/sonalyze/load/load.go
@@ -48,6 +48,8 @@ type LoadCommand struct /* implements SampleAnalysisCommand */ {
 	printOpts   *FormatOptions
 }
 
+var _ SampleAnalysisCommand = (*LoadCommand)(nil)
+
 func (_ *LoadCommand) Summary() []string {
 	return []string{
 		"Compute aggregate system load across various timeframes based on sample",

--- a/code/sonalyze/load/perform.go
+++ b/code/sonalyze/load/perform.go
@@ -18,7 +18,7 @@ func (lc *LoadCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds,
 	hostGlobber *hostglob.HostGlobber,
-	_ func(*sonarlog.Sample) bool,
+	_ db.SampleFilter,
 ) error {
 	fromIncl, toIncl := lc.InterpretFromToWithBounds(bounds)
 

--- a/code/sonalyze/metadata/metadata.go
+++ b/code/sonalyze/metadata/metadata.go
@@ -30,6 +30,8 @@ type MetadataCommand struct /* implements SampleAnalysisCommand */ {
 	printOpts   *FormatOptions
 }
 
+var _ SampleAnalysisCommand = (*MetadataCommand)(nil)
+
 func (_ *MetadataCommand) Summary() []string {
 	return []string{
 		"Display metadata about the sample streams in the database.",
@@ -118,7 +120,7 @@ func (mdc *MetadataCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds,
 	hostGlobber *hostglob.HostGlobber,
-	_ func(*sonarlog.Sample) bool,
+	_ db.SampleFilter,
 ) error {
 	if mdc.Times {
 		fmt.Fprintf(out, "From: %s\n", mdc.FromDate.Format(time.RFC3339))

--- a/code/sonalyze/parse/parse.go
+++ b/code/sonalyze/parse/parse.go
@@ -30,6 +30,8 @@ type ParseCommand struct /* implements SampleAnalysisCommand */ {
 	printOpts   *FormatOptions
 }
 
+var _ SampleAnalysisCommand = (*ParseCommand)(nil)
+
 func (_ *ParseCommand) Summary() []string {
 	return []string{
 		"Export sample data in various formats, after optional preprocessing.",
@@ -93,7 +95,7 @@ func (pc *ParseCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds,
 	hostGlobber *hostglob.HostGlobber,
-	recordFilter func(*sonarlog.Sample) bool,
+	recordFilter db.SampleFilter,
 ) error {
 	var mergedSamples []*sonarlog.SampleStream
 	var samples sonarlog.SampleStream
@@ -116,7 +118,7 @@ func (pc *ParseCommand) Perform(
 		// We still need to filter the records or things will be very confusing
 		if recordFilter != nil {
 			mapped = slices.Filter(mapped, func (s sonarlog.Sample) bool {
-				return recordFilter(&s)
+				return recordFilter(s.S)
 			})
 		}
 		samples = sonarlog.SampleStream(mapped)

--- a/code/sonalyze/parse/parse.go
+++ b/code/sonalyze/parse/parse.go
@@ -108,6 +108,9 @@ func (pc *ParseCommand) Perform(
 		if err != nil {
 			return err
 		}
+
+		// TODO: Merge these loops?  Or don't we care for this case?
+
 		// Simulate the normal pipeline
 		mapped := slices.Map(
 			records,

--- a/code/sonalyze/parse/parse.go
+++ b/code/sonalyze/parse/parse.go
@@ -109,22 +109,14 @@ func (pc *ParseCommand) Perform(
 			return err
 		}
 
-		// TODO: Merge these loops?  Or don't we care for this case?
-
-		// Simulate the normal pipeline
-		mapped := slices.Map(
+		// Simulate the normal pipeline, the recordFilter application is expected by the user.
+		samples = sonarlog.SampleStream(slices.FilterMap(
 			records,
+			recordFilter,
 			func(r *db.Sample) sonarlog.Sample {
 				return sonarlog.Sample{S: r}
 			},
-		)
-		// We still need to filter the records or things will be very confusing
-		if recordFilter != nil {
-			mapped = slices.Filter(mapped, func (s sonarlog.Sample) bool {
-				return recordFilter(s.S)
-			})
-		}
-		samples = sonarlog.SampleStream(mapped)
+		))
 
 	case pc.Clean:
 		mergedSamples = maps.Values(streams)

--- a/code/sonalyze/profile/perform.go
+++ b/code/sonalyze/profile/perform.go
@@ -21,7 +21,7 @@ func (pc *ProfileCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	_ sonarlog.Timebounds,
 	_ *hostglob.HostGlobber,
-	_ func(*sonarlog.Sample) bool,
+	_ db.SampleFilter,
 ) error {
 	jobId := pc.Job[0]
 

--- a/code/sonalyze/profile/profile.go
+++ b/code/sonalyze/profile/profile.go
@@ -24,6 +24,8 @@ type ProfileCommand struct /* implements SampleAnalysisCommand */ {
 	testNoMemory bool
 }
 
+var _ SampleAnalysisCommand = (*ProfileCommand)(nil)
+
 func (_ *ProfileCommand) Summary() []string {
 	return []string{
 		"Print profile information for one aspect of a particular job.",

--- a/code/sonalyze/sonarlog/ingest.go
+++ b/code/sonalyze/sonarlog/ingest.go
@@ -26,6 +26,7 @@ func ReadSampleStreams(
 	c db.SampleCluster,
 	fromDate, toDate time.Time,
 	hostGlobber *hostglob.HostGlobber,
+	recordFilter db.SampleFilter,
 	verbose bool,
 ) (
 	streams InputStreamSet,
@@ -38,7 +39,7 @@ func ReadSampleStreams(
 		return
 	}
 	read = len(samples)
-	streams, bounds = createInputStreams(samples)
+	streams, bounds = createInputStreams(samples, recordFilter)
 	return
 }
 

--- a/code/sonalyze/sonarlog/postprocess.go
+++ b/code/sonalyze/sonarlog/postprocess.go
@@ -169,7 +169,7 @@ func createInputStreams(entries []*db.Sample) (InputStreamSet, Timebounds) {
 //
 // This updates the individual streams and will also remove empty streams from the set.
 
-func ComputeAndFilter(streams InputStreamSet, filter func(*Sample) bool) {
+func ComputeAndFilter(streams InputStreamSet, filter db.SampleFilter) {
 	// For each stream, compute the cpu_util_pct field of each record.
 	//
 	// For v0.7.0 and later, compute this as the difference in cputime_sec between adjacent records
@@ -205,7 +205,7 @@ func ComputeAndFilter(streams InputStreamSet, filter func(*Sample) bool) {
 		es := *stream
 		for src := range es {
 			// See comments above re the test for cpu_util_pct
-			if (filter == nil || filter(&es[src])) && es[src].CpuUtilPct >= 0 {
+			if (filter == nil || filter(es[src].S)) && es[src].CpuUtilPct >= 0 {
 				es[dst] = es[src]
 				dst++
 			}

--- a/code/sonalyze/sonarlog/postprocess_test.go
+++ b/code/sonalyze/sonarlog/postprocess_test.go
@@ -83,7 +83,9 @@ func TestPostprocessLogCpuUtilPct(t *testing.T) {
 
 	root := StringToUstr("root")
 	streams, _ := createInputStreams(entries)
-	ComputeAndFilter(streams, func(r *Sample) bool { return r.S.User != root })
+	ComputeAndFilter(streams, func(r *db.Sample) bool {
+		return r.User != root
+	})
 
 	if len(streams) != 4 {
 		t.Fatalf("Expected 4 streams, got %d", len(streams))

--- a/code/sonalyze/sonarlog/postprocess_test.go
+++ b/code/sonalyze/sonarlog/postprocess_test.go
@@ -82,10 +82,11 @@ func TestPostprocessLogCpuUtilPct(t *testing.T) {
 	}
 
 	root := StringToUstr("root")
-	streams, _ := createInputStreams(entries)
-	ComputeAndFilter(streams, func(r *db.Sample) bool {
+	filter := func(r *db.Sample) bool {
 		return r.User != root
-	})
+	}
+	streams, _ := createInputStreams(entries, filter)
+	ComputePerSampleFields(streams)
 
 	if len(streams) != 4 {
 		t.Fatalf("Expected 4 streams, got %d", len(streams))

--- a/code/sonalyze/uptime/perform.go
+++ b/code/sonalyze/uptime/perform.go
@@ -88,7 +88,7 @@ func (uc *UptimeCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds,
 	hostGlobber *hostglob.HostGlobber,
-	_ func(*sonarlog.Sample) bool,
+	_ db.SampleFilter,
 ) error {
 	samples := slices.CatenateP(maps.Values(streams))
 	if uc.Verbose {

--- a/code/sonalyze/uptime/uptime.go
+++ b/code/sonalyze/uptime/uptime.go
@@ -26,6 +26,8 @@ type UptimeCommand struct /* implements SampleAnalysisCommand */ {
 	printOpts   *FormatOptions
 }
 
+var _ SampleAnalysisCommand = (*UptimeCommand)(nil)
+
 func (_ *UptimeCommand) Summary() []string {
 	return []string{
 		"Compute and print information about uptime and downtime of nodes",


### PR DESCRIPTION
By moving filtering earlier in the pipeline, we greatly reduce (in common cases) the number of records considered for further processing.  This can result in dramatic speedups when the initial record selection is broad (large system, weeks of data, no node filtering).
