### PR TITLE
For #526 - Change DB APIs to return slice-of-slice with shared data

### DIFF
--- a/code/sonalyze/db/persistentcluster.go
+++ b/code/sonalyze/db/persistentcluster.go
@@ -262,7 +262,7 @@ func (pc *PersistentCluster) ReadSamples(
 	fromDate, toDate time.Time,
 	hosts *hostglob.HostGlobber,
 	verbose bool,
-) (samples []*Sample, dropped int, err error) {
+) (sampleBlobs [][]*Sample, dropped int, err error) {
 	if DEBUG {
 		Assert(fromDate.Location() == time.UTC, "UTC expected")
 		Assert(toDate.Location() == time.UTC, "UTC expected")
@@ -277,7 +277,7 @@ func (pc *PersistentCluster) ReadLoadData(
 	fromDate, toDate time.Time,
 	hosts *hostglob.HostGlobber,
 	verbose bool,
-) (data []*LoadDatum, dropped int, err error) {
+) (dataBlobs [][]*LoadDatum, dropped int, err error) {
 	if DEBUG {
 		Assert(fromDate.Location() == time.UTC, "UTC expected")
 		Assert(toDate.Location() == time.UTC, "UTC expected")
@@ -292,7 +292,7 @@ func (pc *PersistentCluster) ReadSysinfo(
 	fromDate, toDate time.Time,
 	hosts *hostglob.HostGlobber,
 	verbose bool,
-) (samples []*config.NodeConfigRecord, dropped int, err error) {
+) (sysinfoBlobs [][]*config.NodeConfigRecord, dropped int, err error) {
 	if DEBUG {
 		Assert(fromDate.Location() == time.UTC, "UTC expected")
 		Assert(toDate.Location() == time.UTC, "UTC expected")
@@ -306,7 +306,7 @@ func (pc *PersistentCluster) ReadSysinfo(
 func (pc *PersistentCluster) ReadSacctData(
 	fromDate, toDate time.Time,
 	verbose bool,
-) (records []*SacctInfo, dropped int, err error) {
+) (sacctBlobs [][]*SacctInfo, dropped int, err error) {
 	if DEBUG {
 		Assert(fromDate.Location() == time.UTC, "UTC expected")
 		Assert(toDate.Location() == time.UTC, "UTC expected")
@@ -317,7 +317,7 @@ func (pc *PersistentCluster) ReadSacctData(
 	)
 }
 
-func readPersistentClusterRecords[V any, U ~[]*V](
+func readPersistentClusterRecords[V any, U ~[][]*V](
 	pc *PersistentCluster,
 	fromDate, toDate time.Time,
 	hosts *hostglob.HostGlobber,
@@ -325,7 +325,7 @@ func readPersistentClusterRecords[V any, U ~[]*V](
 	fa filesAdapter,
 	methods ReadSyncMethods,
 	reader func(files []*LogFile, verbose bool, methods ReadSyncMethods) (U, int, error),
-) (records U, dropped int, err error) {
+) (recordBlobs U, dropped int, err error) {
 	// TODO: IMPROVEME: Don't hold the lock while reading, it's not necessary, caching is per-file
 	// and does not interact with the cluster.  But be sure to get pc.cfg while holding the lock.
 	pc.Lock()

--- a/code/sonalyze/db/sacctfile.go
+++ b/code/sonalyze/db/sacctfile.go
@@ -53,6 +53,6 @@ func readSacctSlice(
 	files []*LogFile,
 	verbose bool,
 	reader ReadSyncMethods,
-) ([]*SacctInfo, int, error) {
+) ([][]*SacctInfo, int, error) {
 	return readRecordsFromFiles[SacctInfo](files, verbose, reader)
 }

--- a/code/sonalyze/db/samplefile.go
+++ b/code/sonalyze/db/samplefile.go
@@ -100,7 +100,7 @@ func readSampleSlice(
 	files []*LogFile,
 	verbose bool,
 	reader ReadSyncMethods,
-) (samples []*Sample, dropped int, err error) {
+) (sampleBlobs [][]*Sample, dropped int, err error) {
 	return readRecordsFromFiles[Sample](files, verbose, reader)
 }
 
@@ -108,6 +108,6 @@ func readLoadDatumSlice(
 	files []*LogFile,
 	verbose bool,
 	reader ReadSyncMethods,
-) (samples []*LoadDatum, dropped int, err error) {
+) (loadDataBlobs [][]*LoadDatum, dropped int, err error) {
 	return readRecordsFromFiles[LoadDatum](files, verbose, reader)
 }

--- a/code/sonalyze/db/sysinfofile.go
+++ b/code/sonalyze/db/sysinfofile.go
@@ -39,6 +39,6 @@ func readNodeConfigRecordSlice(
 	files []*LogFile,
 	verbose bool,
 	reader ReadSyncMethods,
-) ([]*config.NodeConfigRecord, int, error) {
+) ([][]*config.NodeConfigRecord, int, error) {
 	return readRecordsFromFiles[config.NodeConfigRecord](files, verbose, reader)
 }

--- a/code/sonalyze/db/transientcluster.go
+++ b/code/sonalyze/db/transientcluster.go
@@ -110,7 +110,7 @@ func (tsc *TransientSampleCluster) ReadSamples(
 	_, _ time.Time,
 	_ *hostglob.HostGlobber,
 	verbose bool,
-) (samples []*Sample, dropped int, err error) {
+) (sampleBlobs [][]*Sample, dropped int, err error) {
 	tsc.Lock()
 	defer tsc.Unlock()
 	if tsc.closed {
@@ -124,7 +124,7 @@ func (tsc *TransientSampleCluster) ReadLoadData(
 	_, _ time.Time,
 	_ *hostglob.HostGlobber,
 	verbose bool,
-) (data []*LoadDatum, dropped int, err error) {
+) (dataBlobs [][]*LoadDatum, dropped int, err error) {
 	tsc.Lock()
 	defer tsc.Unlock()
 	if tsc.closed {
@@ -161,7 +161,7 @@ func (tsc *TransientSacctCluster) SacctFilenames(_, _ time.Time) ([]string, erro
 func (tsc *TransientSacctCluster) ReadSacctData(
 	fromDate, toDate time.Time,
 	verbose bool,
-) (records []*SacctInfo, dropped int, err error) {
+) (recordBlobs [][]*SacctInfo, dropped int, err error) {
 	tsc.Lock()
 	defer tsc.Unlock()
 	if tsc.closed {

--- a/code/sonalyze/sacct/perform.go
+++ b/code/sonalyze/sacct/perform.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"go-utils/hostglob"
+	uslices "go-utils/slices"
 
 	. "sonalyze/common"
 	"sonalyze/db"
@@ -39,7 +40,7 @@ func (sc *SacctCommand) Sacct(_ io.Reader, stdout, stderr io.Writer) error {
 
 	// Read the raw sacct data.
 
-	records, dropped, err := theLog.ReadSacctData(
+	recordBlobs, dropped, err := theLog.ReadSacctData(
 		sc.FromDate,
 		sc.ToDate,
 		sc.Verbose,
@@ -47,6 +48,9 @@ func (sc *SacctCommand) Sacct(_ io.Reader, stdout, stderr io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("Failed to read log records\n%w", err)
 	}
+	// TODO: The catenation is expedient, we should be looping over the nested set (or in the
+	// future, using an iterator).
+	records := uslices.Catenate(recordBlobs)
 	if sc.Verbose {
 		Log.Infof("%d records read + %d dropped", len(records), dropped)
 		UstrStats(stderr, false)

--- a/code/sonalyze/sonarlog/ingest.go
+++ b/code/sonalyze/sonarlog/ingest.go
@@ -34,12 +34,14 @@ func ReadSampleStreams(
 	read, dropped int,
 	err error,
 ) {
-	samples, dropped, err := c.ReadSamples(fromDate, toDate, hostGlobber, verbose)
+	sampleBlobs, dropped, err := c.ReadSamples(fromDate, toDate, hostGlobber, verbose)
 	if err != nil {
 		return
 	}
-	read = len(samples)
-	streams, bounds = createInputStreams(samples, recordFilter)
+	for _, samples := range sampleBlobs {
+		read += len(samples)
+	}
+	streams, bounds = createInputStreams(sampleBlobs, recordFilter)
 	return
 }
 
@@ -56,12 +58,14 @@ func ReadLoadDataStreams(
 ) {
 	// Read and establish invariants
 
-	data, dropped, err := c.ReadLoadData(fromDate, toDate, hostGlobber, verbose)
+	dataBlobs, dropped, err := c.ReadLoadData(fromDate, toDate, hostGlobber, verbose)
 	if err != nil {
 		return
 	}
-	read = len(data)
-	streams, bounds, errors := rectifyLoadData(data)
+	for _, data := range dataBlobs {
+		read += len(data)
+	}
+	streams, bounds, errors := rectifyLoadData(dataBlobs)
 	dropped += errors
 	return
 }

--- a/code/sonalyze/sonarlog/postprocess_test.go
+++ b/code/sonalyze/sonarlog/postprocess_test.go
@@ -43,17 +43,19 @@ func TestRectifyGpuMem(t *testing.T) {
 	// gpumem%=12 so we should see a computed value for gpukib which is different from the gpukib
 	// figure in the data.
 	var notime time.Time
-	samples, _, err := c.ReadSamples(notime, notime, nil, false)
+	sampleBlobs, _, err := c.ReadSamples(notime, notime, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	found := 0
 	expect := uint64((memsize * 12) / 100 * 1024 * 1024)
-	for _, s := range samples {
-		if s.Job == 1249151 {
-			found++
-			if s.GpuKib != expect {
-				t.Errorf("GpuKib %v expected %v (%v %v)", s.GpuKib, expect, s.GpuPct, s.GpuMemPct)
+	for _, samples := range sampleBlobs {
+		for _, s := range samples {
+			if s.Job == 1249151 {
+				found++
+				if s.GpuKib != expect {
+					t.Errorf("GpuKib %v expected %v (%v %v)", s.GpuKib, expect, s.GpuPct, s.GpuMemPct)
+				}
 			}
 		}
 	}
@@ -85,7 +87,7 @@ func TestPostprocessLogCpuUtilPct(t *testing.T) {
 	filter := func(r *db.Sample) bool {
 		return r.User != root
 	}
-	streams, _ := createInputStreams(entries, filter)
+	streams, _ := createInputStreams([][]*db.Sample{entries}, filter)
 	ComputePerSampleFields(streams)
 
 	if len(streams) != 4 {


### PR DESCRIPTION
This takes a lot of pressure off allocation and GC for large initial data sets by not allocating one ginormous slice to hold them all, but to allocate a smaller slice to hold a set of inner slices that we get from the storage layer.  It complicates the API but it shaves 25% off the running time of the heavy-users.py code compared to existing code.