### PR TITLE
Fix #630 - do not recompress compressed host names

### DIFF
--- a/code/tests/sonalyze/jobs/r630_compress_hosts.csv
+++ b/code/tests/sonalyze/jobs/r630_compress_hosts.csv
@@ -1,0 +1,12 @@
+v=0.12.1,time=2024-10-22T01:05:01Z,host=c1-18.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=482.1,cpukib=782252,cputime_sec=335,rolledup=4
+v=0.12.1,time=2024-10-22T01:10:01Z,host=c1-18.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=493.9,cpukib=782252,cputime_sec=1824,rolledup=4
+v=0.12.1,time=2024-10-22T01:15:02Z,host=c1-18.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=494.3,cpukib=782252,cputime_sec=3314,rolledup=4
+v=0.12.1,time=2024-10-22T01:20:01Z,host=c1-18.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=494.9,cpukib=782252,cputime_sec=4799,rolledup=4
+v=0.12.1,time=2024-10-22T01:05:01Z,host=c1-10.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=579.7,cpukib=1616736,cputime_sec=401,rolledup=5
+v=0.12.1,time=2024-10-22T01:10:01Z,host=c1-10.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=593.8,cpukib=1616796,cputime_sec=2193,rolledup=5
+v=0.12.1,time=2024-10-22T01:15:01Z,host=c1-10.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=594.2,cpukib=1616796,cputime_sec=3976,rolledup=5
+v=0.12.1,time=2024-10-22T01:20:01Z,host=c1-10.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=595,cpukib=1616796,cputime_sec=5769,rolledup=5
+v=0.12.1,time=2024-10-22T01:05:01Z,host=c1-19.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=2030.5,cpukib=3269516,cputime_sec=1407,rolledup=20
+v=0.12.1,time=2024-10-22T01:10:01Z,host=c1-19.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=2076,cpukib=3269516,cputime_sec=7665,rolledup=20
+v=0.12.1,time=2024-10-22T01:15:02Z,host=c1-19.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=2077,cpukib=3269516,cputime_sec=13924,rolledup=20
+v=0.12.1,time=2024-10-22T01:20:01Z,host=c1-19.fox,cores=0,user=ec-testuser,job=937627,cmd=rosetta_scripts,cpu%=2080.5,cpukib=3269516,cputime_sec=20161,rolledup=20

--- a/code/tests/sonalyze/jobs/r630_compress_hosts.sh
+++ b/code/tests/sonalyze/jobs/r630_compress_hosts.sh
@@ -1,0 +1,36 @@
+# Regression test for issue #630 - jobs printer would wrongly recompress compressed hosts.
+#
+# Test data were obtained from production data by:
+#
+#   sonalyze parse -job 937627 -f 2d -fmt csvnamed,roundtrip,nodefaults
+#     -data-dir ~/sonar/data/fox.educloud.no
+#     -config-file ~/sonar/cluster-config/fox.educloud.no-config.json
+#
+# and the user name subsequently anonymised.
+
+# This used to print "c1-[101918-,].fox" for the host name
+output=$($SONALYZE jobs --user - -f 2024-10-21 --fmt=csv,host,user,job,cmd -config-file r630_conf.json -- r630_compress_hosts.csv)
+CHECK r630_conf_merge '"c1-[10,18-19].fox",ec-testuser,937627,rosetta_scripts' "$output"
+
+# Fixed output keeps only the node name not domain
+output=$($SONALYZE jobs --user - -f 2024-10-21 --fmt=noheader,host,user,job,cmd -config-file r630_conf.json -- r630_compress_hosts.csv)
+CHECK r630_conf_merge_fixed 'c1-[10,18-19]  ec-testuser  937627  rosetta_scripts' "$output"
+
+# This used to print "c1-[101918-,].fox" for the host name
+output=$($SONALYZE jobs --batch --user - -f 2024-10-21 --fmt=csv,host,user,job,cmd -- r630_compress_hosts.csv)
+CHECK r630_batch_merge '"c1-[10,18-19].fox",ec-testuser,937627,rosetta_scripts' "$output"
+
+# This was never broken but it's the third possible case.
+#
+# The extra sort is because there's no sorting by host name in the output from sonalyze at present.
+# A sensible strategy would be to sort the records in field order, adapting to whatever spec is
+# requested, or by specifying sort fields as an extra parameter.
+output=$($SONALYZE jobs --user - -f 2024-10-21 --fmt=csv,host,user,job,cmd -- r630_compress_hosts.csv | sort)
+CHECK r630_no_merge 'c1-10.fox,ec-testuser,937627,rosetta_scripts
+c1-18.fox,ec-testuser,937627,rosetta_scripts
+c1-19.fox,ec-testuser,937627,rosetta_scripts' "$output"
+
+output=$($SONALYZE jobs --user - -f 2024-10-21 --fmt=noheader,host,user,job,cmd -- r630_compress_hosts.csv | sort)
+CHECK r630_no_merge_fixed 'c1-10  ec-testuser  937627  rosetta_scripts
+c1-18  ec-testuser  937627  rosetta_scripts
+c1-19  ec-testuser  937627  rosetta_scripts' "$output"

--- a/code/tests/sonalyze/jobs/r630_conf.json
+++ b/code/tests/sonalyze/jobs/r630_conf.json
@@ -1,0 +1,14 @@
+{
+    "name":"fox.educloud.no",
+    "aliases":["fox"],
+    "description":"UiO 'Fox' supercomputer",
+    "nodes": [
+        {
+            "hostname": "c1-[5-29].fox",
+            "description": "2x64 AMD EPYC 7702 64-Core Processor, 503 GB",
+            "cross_node_jobs":true,
+            "cpu_cores": 128,
+            "mem_gb": 503
+        }
+    ]
+}


### PR DESCRIPTION
Remove the compression in the printing code.  If this is going to do compression, it needs to be a lot more sophisticated.

I still need to add some test cases for this, and consider any paths that might end up with a lot of output due to lists of compressible but uncompressed host names.