### PR TITLE
Fix #634 - add -merge-none and -merge-all flags

### DIFF
--- a/code/go-utils/config/config.go
+++ b/code/go-utils/config/config.go
@@ -41,7 +41,8 @@
 //   cross_node_jobs - bool, optional, expressing that jobs on this node can be merged with
 //                     jobs on other nodes in the same cluster where the flag is also set,
 //                     because the job numbers come from the same cluster-wide source
-//                     (typically slurm).  Also see the --batch option.
+//                     (typically slurm).  Also see the --merge-all and --merge-none options
+//                     to `sonalyze jobs`.
 //   cpu_cores - integer, the number of hyperthreads
 //   mem_gb - integer, the amount of main memory in gigabytes
 //   gpu_cards - integer, the number of gpu cards on the node

--- a/code/naicreport/glance/glance.go
+++ b/code/naicreport/glance/glance.go
@@ -307,7 +307,7 @@ func collectUsersAndJobs(
 	var rawData []*sonalyzeJobsData
 	err := runAndUnmarshal(
 		sonalyzePath,
-		[]string{"jobs", "--user", "-", "--fmt=json,host,user,classification,end"},
+		[]string{"jobs", "-user", "-", "-merge-none", "-fmt=json,host,user,classification,end"},
 		progOpts,
 		&rawData,
 	)
@@ -402,8 +402,8 @@ func collectStatusData(sonalyzePath string, progOpts *optionsPkg) ([]*systemStat
 		sonalyzePath,
 		[]string{
 			"uptime",
-			"--interval", fmt.Sprint(UPTIME_MINS),
-			"--fmt=json,host,device,state",
+			"-interval", fmt.Sprint(UPTIME_MINS),
+			"-fmt=json,host,device,state",
 		},
 		progOpts,
 		&rawData)
@@ -475,7 +475,7 @@ func collectLoadAverages(
 	recentData, err := collectLoadAveragesOnce(
 		sonalyzePath,
 		progOpts,
-		"--half-hourly")
+		"-half-hourly")
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +486,7 @@ func collectLoadAverages(
 	longerData, err := collectLoadAveragesOnce(
 		sonalyzePath,
 		progOpts,
-		"--half-daily")
+		"-half-daily")
 	if err != nil {
 		return nil, err
 	}
@@ -568,7 +568,7 @@ func collectLoadAveragesOnce(
 		[]string{
 			"load",
 			bucketArg,
-			"--fmt=json,host,rcpu,rmem,rres,rgpu,rgpumem"},
+			"-fmt=json,host,rcpu,rmem,rres,rgpu,rgpumem"},
 		progOpts,
 		&rawData)
 	if err != nil {

--- a/code/sonalyze/MANUAL.md
+++ b/code/sonalyze/MANUAL.md
@@ -199,10 +199,16 @@ filters.
 These are only available with the `jobs` command.  All filters are optional.  Jobs must pass all
 specified filters.
 
-`-b`, `--batch`
+`--merge-all`, `--batch`
 
   Aggregate data across hosts (this would normally be appropriate for systems with a batch queue,
-  such as Fox).
+  such as Fox).  Normally this flag comes from the config file; this is an override.
+
+`--merge-none`
+
+  Never aggregate data across hosts (this would normally be appropriate for systems without a batch
+  queue, such as the UiO ML nodes).  Normally this flag comes from the config file; this is an
+  override.
 
 `--min-cpu-avg=<pct>`, `--max-cpu-avg=<pct>`
 
@@ -392,9 +398,11 @@ with `-array` and `-het`.
 
 `--breakdown=<keywords>`
 
+  NOT CURRENTLY IMPLEMENTED.
+
   For a job, also print a breakdown according to the `<keywords>`.  The keywords are `host` and
   `command` and can be present in either order.  Suppose jobs are aggregated across hosts (with
-  `--batch`) and that the jobs may run as multiple processes with different names.  Adding
+  `--merge-all`) and that the jobs may run as multiple processes with different names.  Adding
   `--breakdown=host,command` will show the summary for the job, but then break it down by host, and
   for each host, break it down by command, showing a summary line per host (across all the commands
   on that host) and then a line for each command.  This yields insight into how the different


### PR DESCRIPTION
In addition to this initial change to sonalyze, naicreport must pass the -merge-none switch when performing its initial jobs enumeration.