### PR TITLE
For #679 - do not generate some sensitive reports

### DIFF
--- a/production/jobanalyzer-server/scripts/fox.educloud.no/deadweight-report.sh
+++ b/production/jobanalyzer-server/scripts/fox.educloud.no/deadweight-report.sh
@@ -19,4 +19,4 @@ $naicreport_dir/naicreport deadweight -state-dir $state_dir -from 4w > $report_d
 if [[ -s $report_dir/fox-deadweight-report.txt ]]; then
     $naicreport_mail -s "Fox deadweight report" "$fox_deadweight_recipient" < $report_dir/fox-deadweight-report.txt
 fi
-$naicreport_dir/naicreport deadweight -state-dir $state_dir -from 4w -json > $report_dir/fox-deadweight-report.json
+#$naicreport_dir/naicreport deadweight -state-dir $state_dir -from 4w -json > $report_dir/fox-deadweight-report.json

--- a/production/jobanalyzer-server/scripts/mlx.hpc.uio.no/cpuhog-report.sh
+++ b/production/jobanalyzer-server/scripts/mlx.hpc.uio.no/cpuhog-report.sh
@@ -19,4 +19,4 @@ $naicreport_dir/naicreport ml-cpuhog -state-dir $state_dir -from 4w > $report_di
 if [[ -s $report_dir/ml-violator-report.txt ]]; then
     $naicreport_mail -s "ML violator report" "$ml_violator_recipient" < $report_dir/ml-violator-report.txt
 fi
-$naicreport_dir/naicreport ml-cpuhog -state-dir $state_dir -from 4w -json > $report_dir/ml-violator-report.json
+#$naicreport_dir/naicreport ml-cpuhog -state-dir $state_dir -from 4w -json > $report_dir/ml-violator-report.json

--- a/production/jobanalyzer-server/scripts/mlx.hpc.uio.no/deadweight-report.sh
+++ b/production/jobanalyzer-server/scripts/mlx.hpc.uio.no/deadweight-report.sh
@@ -19,4 +19,4 @@ $naicreport_dir/naicreport deadweight -state-dir $state_dir -from 4w > $report_d
 if [[ -s $report_dir/ml-deadweight-report.txt ]]; then
     $naicreport_mail -s "ML deadweight report" "$ml_deadweight_recipient" < $report_dir/ml-deadweight-report.txt
 fi
-$naicreport_dir/naicreport deadweight -state-dir $state_dir -from 4w -json > $report_dir/ml-deadweight-report.json
+#$naicreport_dir/naicreport deadweight -state-dir $state_dir -from 4w -json > $report_dir/ml-deadweight-report.json


### PR DESCRIPTION
Basically a hack, but works well enough.  By not generating these they won't be uploaded and this information won't be visible, no matter what the dashboard does.  (The text files are still generated b/c they are emailed to RT.)