### PR TITLE
For #615 - Clean up jobs formatting

### DIFF
--- a/code/sonalyze/cmd/cli.go
+++ b/code/sonalyze/cmd/cli.go
@@ -24,17 +24,17 @@ type CLI struct {
 var (
 	// All known options *must* be here but there can be repeated sort values
 	priority = map[string]int{
-		"application-control": 1,
+		"application-control":  1,
 		"daemon-configuration": 1,
-		"data-target": 1,
-		"operation-selection": 1,
-		"aggregation": 2,
-		"job-filter": 3,
-		"printing": 4,
-		"record-filter": 5,
-		"remote-data-source": 6,
-		"local-data-source": 7,
-		"development": 8,
+		"data-target":          1,
+		"operation-selection":  1,
+		"aggregation":          2,
+		"job-filter":           3,
+		"printing":             4,
+		"record-filter":        5,
+		"remote-data-source":   6,
+		"local-data-source":    7,
+		"development":          8,
 	}
 )
 
@@ -48,7 +48,7 @@ func NewCLI(verb string, command Command, name string, exitOnError bool) *CLI {
 		fsFlag = flag.ExitOnError
 	}
 	cli := &CLI{
-		FlagSet: flag.NewFlagSet(name, fsFlag),
+		FlagSet:        flag.NewFlagSet(name, fsFlag),
 		groupForOption: make(map[string]string),
 	}
 	out := CLIOutput()
@@ -124,7 +124,7 @@ func (cli *CLI) tag(option string) {
 
 type defaultGroup struct {
 	group string
-	text []string
+	text  []string
 }
 
 func (cli *CLI) getSortedDefaults(restArgs bool) []defaultGroup {
@@ -199,4 +199,3 @@ func (cli *CLI) extendGroup(
 
 // Brittle!  Wants a test case!
 var optRe = regexp.MustCompile(`^  -(\S+)`)
-

--- a/code/sonalyze/cmd/jobs/print.go
+++ b/code/sonalyze/cmd/jobs/print.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	_ "reflect"
 	"slices"
+	"strings"
 
 	uslices "go-utils/slices"
 
@@ -91,12 +92,300 @@ jobs
   format is 'fixed'.
 `
 
-const jobsDefaultFields = "std,cpu,mem,gpu,gpumem,cmd"
+const v0JobsDefaultFields = "std,cpu,mem,gpu,gpumem,cmd"
+const v1JobsDefaultFields = "Std,Cpu,Mem,Gpu,GpuMem,Cmd"
+const jobsDefaultFields = v0JobsDefaultFields
+
+// Instead of struggling with how to represent formatters for the indexed accesses, just define
+// the formatters directly, and handle aliases below.
+
+// MT: Constant after initialization; immutable
+var jobsFormatters = map[string]Formatter{
+	"JobAndMark": {
+		Fmt: func(d any, _ PrintMods) string {
+			return d.(*jobSummary).JobAndMark
+		},
+		Help: "Job ID with mark indicating job running at start+end (!), start (<), or end (>) of time window",
+	},
+	"Job": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(d.(*jobSummary).JobId)
+		},
+		Help: "Job ID",
+	},
+	"User": {
+		Fmt: func(d any, _ PrintMods) string {
+			return d.(*jobSummary).User.String()
+		},
+		Help: "Name of user running the job",
+	},
+	"Duration": {
+		Fmt: func(d any, ctx PrintMods) string {
+			return FormatDurationValue(int64(d.(*jobSummary).Duration), ctx)
+		},
+		Help: "Duration of job: time of last observation minus time of first",
+	},
+	"Start": {
+		Fmt: func(d any, ctx PrintMods) string {
+			return FormatDateTimeValue(int64(d.(*jobSummary).Start), ctx)
+		},
+		Help: "Time of first observation",
+	},
+	"End": {
+		Fmt: func(d any, ctx PrintMods) string {
+			return FormatDateTimeValue(int64(d.(*jobSummary).End), ctx)
+		},
+		Help: "Time of last observation",
+	},
+	"CpuAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kCpuPctAvg])))
+		},
+		Help: "Average CPU utilization in percent (100% = 1 core)",
+	},
+	"CpuPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kCpuPctPeak])))
+		},
+		Help: "Peak CPU utilization in percent (100% = 1 core)",
+	},
+	"RelativeCpuAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRcpuPctAvg])))
+		},
+		Help: "Average relative CPU utilization in percent (100% = all cores)",
+	},
+	"RelativeCpuPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRcpuPctPeak])))
+		},
+		Help: "Peak relative CPU utilization in percent (100% = all cores)",
+	},
+	"MemAvgGB": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kCpuGBAvg])))
+		},
+		Help: "Average main virtual memory utilization in GB",
+	},
+	"MemPeakGB": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kCpuGBPeak])))
+		},
+		Help: "Peak main virtual memory utilization in GB",
+	},
+	"RelativeMemAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRcpuGBAvg])))
+		},
+		Help: "Average relative main virtual memory utilization in percent (100% = system RAM)",
+	},
+	"RelativeMemPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRcpuGBPeak])))
+		},
+		Help: "Peak relative main virtual memory utilization in percent (100% = system RAM)",
+	},
+	"ResidentMemAvgGB": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRssAnonGBAvg])))
+		},
+		Help: "Average main resident memory utilization in GB",
+	},
+	"ResidentMemPeakGB": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRssAnonGBPeak])))
+		},
+		Help: "Peak main resident memory utilization in GB",
+	},
+	"RelativeResidentMemAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRrssAnonGBAvg])))
+		},
+		Help: "Average relative main resident memory utilization in percent (100% = all RAM)",
+	},
+	"RelativeResidentMemPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRrssAnonGBPeak])))
+		},
+		Help: "Peak relative main resident memory utilization in percent (100% = all RAM)",
+	},
+	"GpuAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kGpuPctAvg])))
+		},
+		Help: "Average GPU utilization in percent (100% = 1 card)",
+	},
+	"GpuPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kGpuPctPeak])))
+		},
+		Help: "Peak GPU utilization in percent (100% = 1 card)",
+	},
+	"RelativeGpuAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRgpuPctAvg])))
+		},
+		Help: "Average relative GPU utilization in percent (100% = all cards)",
+	},
+	"RelativeGpuPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRgpuPctPeak])))
+		},
+		Help: "Peak relative GPU utilization in percent (100% = all cards)",
+	},
+	"OccupiedRelativeGpuAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kSgpuPctAvg])))
+		},
+		Help: "Average relative GPU utilization in percent (100% = all cards used by job)",
+	},
+	"OccupiedRelativeGpuPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kSgpuPctPeak])))
+		},
+		Help: "Peak relative GPU utilization in percent (100% = all cards used by job)",
+	},
+	"GpuMemAvgGB": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kGpuGBAvg])))
+		},
+		Help: "Average resident GPU memory utilization in GB",
+	},
+	"GpuMemPeakGB": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kGpuGBPeak])))
+		},
+		Help: "Peak resident GPU memory utilization in GB",
+	},
+	"RelativeGpuMemAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRgpuGBAvg])))
+		},
+		Help: "Average relative GPU resident memory utilization in percent (100% = all GPU RAM)",
+	},
+	"RelativeGpuMemPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRgpuGBPeak])))
+		},
+		Help: "Peak relative GPU resident memory utilization in percent (100% = all GPU RAM)",
+	},
+	"OccupiedRelativeGpuMemAvgPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kSgpuGBAvg])))
+		},
+		Help: "Average relative GPU resident memory utilization in percent (100% = all GPU RAM on cards used by job)",
+	},
+	"OccupiedRelativeGpuMemPeakPct": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kSgpuGBPeak])))
+		},
+		Help: "Peak relative GPU resident memory utilization in percent (100% = all GPU RAM on cards used by job)",
+	},
+	"Gpus": {
+		Fmt: func(d any, _ PrintMods) string {
+			return d.(*jobSummary).Gpus.String()
+		},
+		Help: "GPU device numbers used by the job, 'none' if none or 'unknown' in error states",
+	},
+	"GpuFail": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(d.(*jobSummary).GpuFail)
+		},
+		Help: "Flag indicating GPU status (0=Ok, 1=Failing)",
+	},
+	"Cmd": {
+		Fmt: func(d any, _ PrintMods) string {
+			return d.(*jobSummary).Cmd
+		},
+		Help: "The commands invoking the processes of the job",
+	},
+	"Host": {
+		Fmt: func(d any, _ PrintMods) string {
+			return d.(*jobSummary).Host
+		},
+		Help: "List of the host name(s) running the job (first elements of FQDNs, compressed)",
+	},
+	"Now": {
+		Fmt: func(d any, ctx PrintMods) string {
+			return FormatDateTimeValue(int64(d.(*jobSummary).Now), ctx)
+		},
+		Help: "The current time",
+	},
+	"Classification": {
+		Fmt: func(d any, _ PrintMods) string {
+			return fmt.Sprint(d.(*jobSummary).Classification)
+		},
+		Help: "Bit vector of live-at-start (2) and live-at-end (1) flags",
+	},
+	"CpuTime": {
+		Fmt: func(d any, ctx PrintMods) string {
+			return FormatDurationValue(int64(d.(*jobSummary).CpuTime), ctx)
+		},
+		Help: "Total CPU time of the job across all cores",
+	},
+	"GpuTime": {
+		Fmt: func(d any, ctx PrintMods) string {
+			return FormatDurationValue(int64(d.(*jobSummary).GpuTime), ctx)
+		},
+		Help: "Total GPU time of the job across all cards",
+	},
+}
+
+func init() {
+	// Define aliases for the traditional names
+	DefAlias(jobsFormatters, "JobAndMark", "jobm")
+	DefAlias(jobsFormatters, "Job", "job")
+	DefAlias(jobsFormatters, "User", "user")
+	DefAlias(jobsFormatters, "Duration", "duration")
+	DefAlias(jobsFormatters, "Start", "start")
+	DefAlias(jobsFormatters, "End", "end")
+	DefAlias(jobsFormatters, "CpuAvgPct", "cpu-avg")
+	DefAlias(jobsFormatters, "CpuPeakPct", "cpu-peak")
+	DefAlias(jobsFormatters, "RelativeCpuAvgPct", "rcpu-avg")
+	DefAlias(jobsFormatters, "RelativeCpuPeakPct", "rcpu-peak")
+	DefAlias(jobsFormatters, "MemAvgGB", "mem-avg")
+	DefAlias(jobsFormatters, "MemPeakGB", "mem-peak")
+	DefAlias(jobsFormatters, "RelativeMemAvgPct", "rmem-avg")
+	DefAlias(jobsFormatters, "RelativeMemPeakPct", "rmem-peak")
+	DefAlias(jobsFormatters, "ResidentMemAvgGB", "res-avg")
+	DefAlias(jobsFormatters, "ResidentMemPeakGB", "res-peak")
+	DefAlias(jobsFormatters, "RelativeResidentMemAvgPct", "rres-avg")
+	DefAlias(jobsFormatters, "RelativeResidentMemPeakPct", "rres-peak")
+	DefAlias(jobsFormatters, "GpuAvgPct", "gpu-avg")
+	DefAlias(jobsFormatters, "GpuPeakPct", "gpu-peak")
+	DefAlias(jobsFormatters, "RelativeGpuAvgPct", "rgpu-avg")
+	DefAlias(jobsFormatters, "RelativeGpuPeakPct", "rgpu-peak")
+	DefAlias(jobsFormatters, "OccupiedRelativeGpuAvgPct", "sgpu-avg")
+	DefAlias(jobsFormatters, "OccupiedRelativeGpuPeakPct", "sgpu-peak")
+	DefAlias(jobsFormatters, "GpuMemAvgGB", "gpumem-avg")
+	DefAlias(jobsFormatters, "GpuMemPeakGB", "gpumem-peak")
+	DefAlias(jobsFormatters, "RelativeGpuMemAvgPct", "rgpumem-avg")
+	DefAlias(jobsFormatters, "RelativeGpuMemPeakPct", "rgpumem-peak")
+	DefAlias(jobsFormatters, "OccupiedRelativeGpuMemAvgPct", "sgpumem-avg")
+	DefAlias(jobsFormatters, "OccupiedRelativeGpuMemPeakPct", "sgpumem-peak")
+	DefAlias(jobsFormatters, "Gpus", "gpus")
+	DefAlias(jobsFormatters, "GpuFail", "gpufail")
+	DefAlias(jobsFormatters, "Cmd", "cmd")
+	DefAlias(jobsFormatters, "Host", "host")
+	DefAlias(jobsFormatters, "Now", "now")
+	DefAlias(jobsFormatters, "Classification", "classification")
+	DefAlias(jobsFormatters, "CpuTime", "cputime")
+	DefAlias(jobsFormatters, "GpuTime", "gputime")
+}
 
 // MT: Constant after initialization; immutable
 var jobsAliases = map[string][]string{
-	"default": []string{"jobm", "user", "duration", "host", "cpu", "mem", "gpu", "gpumem", "cmd"},
-	"all":     []string{"jobm", "job", "user", "duration", "duration/sec", "start", "start/sec", "end", "end/sec", "cpu-avg", "cpu-peak", "rcpu-avg", "rcpu-peak", "mem-avg", "mem-peak", "rmem-avg", "rmem-peak", "res-avg", "res-peak", "rres-avg", "rres-peak", "gpu-avg", "gpu-peak", "rgpu-avg", "rgpu-peak", "sgpu-avg", "sgpu-peak", "gpumem-avg", "gpumem-peak", "rgpumem-avg", "rgpumem-peak", "sgpumem-avg", "sgpumem-peak", "gpus", "gpufail", "cmd", "host", "now", "now/sec", "classification", "cputime/sec", "cputime", "gputime/sec", "gputime"},
+	// Traditional names
+	"default": strings.Split(v0JobsDefaultFields, ","),
+	"all": []string{
+		"jobm", "job", "user", "duration", "duration/sec", "start", "start/sec", "end", "end/sec",
+		"cpu-avg", "cpu-peak", "rcpu-avg", "rcpu-peak", "mem-avg", "mem-peak", "rmem-avg",
+		"rmem-peak", "res-avg", "res-peak", "rres-avg", "rres-peak", "gpu-avg", "gpu-peak",
+		"rgpu-avg", "rgpu-peak", "sgpu-avg", "sgpu-peak", "gpumem-avg", "gpumem-peak",
+		"rgpumem-avg", "rgpumem-peak", "sgpumem-avg", "sgpumem-peak", "gpus", "gpufail",
+		"cmd", "host", "now", "now/sec", "classification", "cputime/sec", "cputime",
+		"gputime/sec", "gputime",
+	},
 	"std":     []string{"jobm", "user", "duration", "host"},
 	"cpu":     []string{"cpu-avg", "cpu-peak"},
 	"rcpu":    []string{"rcpu-avg", "rcpu-peak"},
@@ -110,276 +399,32 @@ var jobsAliases = map[string][]string{
 	"gpumem":  []string{"gpumem-avg", "gpumem-peak"},
 	"rgpumem": []string{"rgpumem-avg", "rgpumem-peak"},
 	"sgpumem": []string{"sgpumem-avg", "sgpumem-peak"},
-}
 
-// TODO:
-//  - indexed field access: key: XFA{desc, realname, indexval, attr} is exactly like synthesized ZFA
-//    realname is an array or slice, indexval is an int index, key is the display name, there should be
-//    only one realname[index] entry per key
-//  - does the field need to be "Computed" and not "computed"?
-
-type SFS = SimpleFormatSpec
-type XFA = SynthesizedIndexedFormatSpecWithAttr
-
-/*
-var newJobsFormatters = DefineTableFromMap(
-	reflect.TypeOf((*jobSummary)(nil)).Elem(),
-	map[string]any{
-		"JobAndMark":         SFS{"Job ID with mark indicating job running at start+end (!), start (<), or end (>) of time window", "jobm"},
-		"JobId":              SFS{"Job ID", "job"},
-		"User":               SFS{"Name of user running the job", "user"},
-		"Duration":           SFS{"Duration in minutes of job: time of last observation minus time of first", "duration"},
-		"Start":              SFS{"Time of first observation", "start"},
-		"End":                SFS{"Time of last observation", "end"},
-		"CpuAvgPct":          XFA{"Average CPU utilization in percent (100% = 1 core)", "computed", kCpuPctAvg, "cpu-avg", FmtCeil},
-		"CpuPeakPct":         XFA{"Peak CPU utilization in percent (100% = 1 core)", "computed", kCpuPctPeak, "cpu-peak", FmtCeil},
-		"RelativeCpuAvgPct":  XFA{"Average relative CPU utilization in percent (100% = all cores)", "computed", kRcpuPctAvg, "rcpu-avg", FmtCeil},
-		"RelativeCpuPeakPct": XFA{"Peak relative CPU utilization in percent (100% = all cores)", "computed", kRcpuPctPeak, "rcpu-peak", FmtCeil},
-		"MemAvgGB":           XFA{"Average main virtual memory utilization in GB", "computed", kCpuGBAvg, "mem-avg", FmtCeil},
-		"MemPeakGB":          XFA{"Peak main virtual memory utilization in GB", "computed", kCpuGBPeak, "mem-peak", FmtCeil},
-		//"RelativeMemAvgPct": XFA{},
-		//"RelativeMemPeakPct": XFA{},
-		// ... FIXME ...
-		"Gpus":           SFS{"GPU device numbers used by the job, 'none' if none or 'unknown' in error states", "gpus"},
-		"GpuFail":        SFS{"Flag indicating GPU status (0=Ok, not 0=failing)", "gpufail"},
-		"Cmd":            SFS{"The commands invoking the processes of the job", "cmd"},
-		"Host":           SFS{"List of the host name(s) running the job (first elements of FQDNs, compressed)", "host"},
-		"Now":            SFS{"The current time", "now"},
-		"Classification": SFS{"Bit vector of live-at-start (2) and live-at-end (1) flags", "classification"},
-		"CpuTime":        SFS{"Total CPU time of the job across all cores", "cputime"},
-		"GpuTime":        SFS{"Total GPU time of the job across all cores", "gputime"},
+	// New names
+	"Default": strings.Split(v1JobsDefaultFields, ","),
+	"All": []string{
+		"JobAndMark", "Job", "User", "Duration", "Duration/sec", "Start", "Start/sec", "End",
+		"End/sec", "CpuAvgPct", "CpuPeakPct", "RelativeCpuAvgPct", "RelativeCpuPeakPct", "MemAvgGB",
+		"MemPeakGB", "RelativeMemAvgPct", "RelativeMemPeakPct", "ResidentMemAvgGB",
+		"ResidentMemPeakGB", "RelativeResidentMemAvgPct", "RelativeResidentMemPeakPct",
+		"GpuAvgPct", "GpuPeakPct", "RelativeGpuAvgPct", "RelativeGpuPeakPct",
+		"OccupiedRelativeGpuAvgPct", "OccupiedRelativeGpuPeakPct", "GpuMemAvgGB",
+		"GpuMemPeakGB", "RelativeGpuMemAvgPct", "RelativeGpuMemPeakPct",
+		"OccupiedRelativeGpuMemAvgPct", "OccupiedRelativeGpuMemPeakPct", "Gpus", "GpuFail",
+		"Cmd", "Host", "Now", "Now/sec", "Classification", "CpuTime/sec", "CpuTime",
+		"GpuTime/sec", "GpuTime",
 	},
-)
-*/
-
-// MT: Constant after initialization; immutable
-var jobsFormatters = map[string]Formatter{
-	"jobm": {
-		Fmt: func(d any, _ PrintMods) string {
-			return d.(*jobSummary).JobAndMark
-		},
-		Help: "Job ID with mark indicating job running at start+end (!), start (<), or end (>) of time window",
-	},
-	"job": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(d.(*jobSummary).JobId)
-		},
-		Help: "Job ID",
-	},
-	"user": {
-		Fmt: func(d any, _ PrintMods) string {
-			return d.(*jobSummary).User.String()
-		},
-		Help: "Name of user running the job",
-	},
-	"duration": {
-		Fmt: func(d any, ctx PrintMods) string {
-			return FormatDurationValue(int64(d.(*jobSummary).Duration), ctx)
-		},
-		Help: "Duration of job: time of last observation minus time of first",
-	},
-	"start": {
-		Fmt: func(d any, ctx PrintMods) string {
-			return FormatDateTimeValue(int64(d.(*jobSummary).Start), ctx)
-		},
-		Help: "Time of first observation",
-	},
-	"end": {
-		Fmt: func(d any, ctx PrintMods) string {
-			return FormatDateTimeValue(int64(d.(*jobSummary).End), ctx)
-		},
-		Help: "Time of last observation",
-	},
-	"cpu-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kCpuPctAvg])))
-		},
-		Help: "Average CPU utilization in percent (100% = 1 core)",
-	},
-	"cpu-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kCpuPctPeak])))
-		},
-		Help: "Peak CPU utilization in percent (100% = 1 core)",
-	},
-	"rcpu-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRcpuPctAvg])))
-		},
-		Help: "Average relative CPU utilization in percent (100% = all cores)",
-	},
-	"rcpu-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRcpuPctPeak])))
-		},
-		Help: "Peak relative CPU utilization in percent (100% = all cores)",
-	},
-	"mem-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kCpuGBAvg])))
-		},
-		Help: "Average main virtual memory utilization in GiB",
-	},
-	"mem-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kCpuGBPeak])))
-		},
-		Help: "Peak main virtual memory utilization in GiB",
-	},
-	"rmem-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRcpuGBAvg])))
-		},
-		Help: "Average relative main virtual memory utilization in percent (100% = system RAM)",
-	},
-	"rmem-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRcpuGBPeak])))
-		},
-		Help: "Peak relative main virtual memory utilization in percent (100% = system RAM)",
-	},
-	"res-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRssAnonGBAvg])))
-		},
-		Help: "Average main resident memory utilization in GiB",
-	},
-	"res-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRssAnonGBPeak])))
-		},
-		Help: "Peak main resident memory utilization in GiB",
-	},
-	"rres-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRrssAnonGBAvg])))
-		},
-		Help: "Average relative main resident memory utilization in percent (100% = all RAM)",
-	},
-	"rres-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRrssAnonGBPeak])))
-		},
-		Help: "Peak relative main resident memory utilization in percent (100% = all RAM)",
-	},
-	"gpu-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kGpuPctAvg])))
-		},
-		Help: "Average GPU utilization in percent (100% = 1 card)",
-	},
-	"gpu-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kGpuPctPeak])))
-		},
-		Help: "Peak GPU utilization in percent (100% = 1 card)",
-	},
-	"rgpu-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRgpuPctAvg])))
-		},
-		Help: "Average relative GPU utilization in percent (100% = all cards)",
-	},
-	"rgpu-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRgpuPctPeak])))
-		},
-		Help: "Peak relative GPU utilization in percent (100% = all cards)",
-	},
-	"sgpu-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kSgpuPctAvg])))
-		},
-		Help: "Average relative GPU utilization in percent (100% = all cards used by job)",
-	},
-	"sgpu-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kSgpuPctPeak])))
-		},
-		Help: "Peak relative GPU utilization in percent (100% = all cards used by job)",
-	},
-	"gpumem-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kGpuGBAvg])))
-		},
-		Help: "Average resident GPU memory utilization in GiB",
-	},
-	"gpumem-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kGpuGBPeak])))
-		},
-		Help: "Peak resident GPU memory utilization in GiB",
-	},
-	"rgpumem-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRgpuGBAvg])))
-		},
-		Help: "Average relative GPU resident memory utilization in percent (100% = all GPU RAM)",
-	},
-	"rgpumem-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kRgpuGBPeak])))
-		},
-		Help: "Peak relative GPU resident memory utilization in percent (100% = all GPU RAM)",
-	},
-	"sgpumem-avg": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kSgpuGBAvg])))
-		},
-		Help: "Average relative GPU resident memory utilization in percent (100% = all GPU RAM on cards used by job)",
-	},
-	"sgpumem-peak": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(uint64(math.Ceil(d.(*jobSummary).computed[kSgpuGBPeak])))
-		},
-		Help: "Peak relative GPU resident memory utilization in percent (100% = all GPU RAM on cards used by job)",
-	},
-	"gpus": {
-		Fmt: func(d any, _ PrintMods) string {
-			return d.(*jobSummary).Gpus.String()
-		},
-		Help: "GPU device numbers used by the job, 'none' if none or 'unknown' in error states",
-	},
-	"gpufail": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(d.(*jobSummary).GpuFail)
-		},
-		Help: "Flag indicating GPU status (0=Ok, 1=Failing)",
-	},
-	"cmd": {
-		Fmt: func(d any, _ PrintMods) string {
-			return d.(*jobSummary).Cmd
-		},
-		Help: "The commands invoking the processes of the job",
-	},
-	"host": {
-		Fmt: func(d any, _ PrintMods) string {
-			return d.(*jobSummary).Host
-		},
-		Help: "List of the host name(s) running the job (first elements of FQDNs, compressed)",
-	},
-	"now": {
-		Fmt: func(d any, ctx PrintMods) string {
-			return FormatDateTimeValue(int64(d.(*jobSummary).Now), ctx)
-		},
-		Help: "The current time",
-	},
-	"classification": {
-		Fmt: func(d any, _ PrintMods) string {
-			return fmt.Sprint(d.(*jobSummary).Classification)
-		},
-		Help: "Bit vector of live-at-start (2) and live-at-end (1) flags",
-	},
-	"cputime": {
-		Fmt: func(d any, ctx PrintMods) string {
-			return FormatDurationValue(int64(d.(*jobSummary).CpuTime), ctx)
-		},
-		Help: "Total CPU time of the job across all cores",
-	},
-	"gputime": {
-		Fmt: func(d any, ctx PrintMods) string {
-			return FormatDurationValue(int64(d.(*jobSummary).GpuTime), ctx)
-		},
-		Help: "Total GPU time of the job across all cards",
-	},
+	"Std":                    []string{"JobAndMark", "User", "Duration", "Host"},
+	"Cpu":                    []string{"CpuAvgPct", "CpuPeakPct"},
+	"RelativeCpu":            []string{"RelativeCpuAvgPct", "RelativeCpuPeakPct"},
+	"Mem":                    []string{"MemAvgGB", "MemPeakGB"},
+	"RelativeMem":            []string{"RelativeMemAvgPct", "RelativeMemPeakPct"},
+	"ResidentMem":            []string{"ResidentMemAvgGB", "ResidentMemPeakGB"},
+	"RelativeResidentMem":    []string{"RelativeResidentMemAvgPct", "RelativeResidentMemPeakPct"},
+	"Gpu":                    []string{"GpuAvgPct", "GpuPeakPct"},
+	"RelativeGpu":            []string{"RelativeGpuAvgPct", "RelativeGpuPeakPct"},
+	"OccupiedRelativeGpu":    []string{"OccupiedRelativeGpuAvgPct", "OccupiedRelativeGpuPeakPct"},
+	"GpuMem":                 []string{"GpuMemAvgPct", "GpuMemPeakPct"},
+	"RelativeGpuMem":         []string{"RelativeGpuMemAvgPct", "RelativeGpuMemPeakPct"},
+	"OccupiedRelativeGpuMem": []string{"OccupiedRelativeGpuMemAvgPct", "OccupiedRelativeGpuMemPeakPct"},
 }

--- a/code/sonalyze/help.txt
+++ b/code/sonalyze/help.txt
@@ -1,8 +1,10 @@
--- NOTE, this is the built-in help text for sonalyze.  Each section starts
--- with the text `# keyword - explanation`, followed by arbitrary text.
--- keywords must be unique in the file.  This preamble is ignored.  This
--- file is not meant as a user manual, see MANUAL.md instead or use the
--- command-line help system: `sonalyze help`.
+-- NOTE, this is the built-in help text for sonalyze.  This file is not
+-- meant as a user manual, see MANUAL.md instead or use the command-line
+-- help system: `sonalyze help`.
+--
+-- Each topic starts with the text `# keyword - explanation`, followed by
+-- arbitrary text.  Keywords must be unique in the file.  This preamble is
+-- ignored.
 
 # overview - What is this thing?
 
@@ -120,7 +122,7 @@ records to print.
 ## Print formatting
 
 Sonalyze has a rich formatting system for the data.  Without options, most
-commands print in a human-readable fixed-column format.  For data that is
+commands print in a human-readable fixed-column format.  For data that are
 going to be processed subsequently, it is possible to select other formats:
 CSV, CSV with name tags, AWK (space-separated), JSON, and (in some cases)
 HTML with embedded JavaScript.
@@ -137,7 +139,43 @@ start and end time, and cpu and resident memory usage:
 
   -fmt csvnamed,noheader,nodefault,job,user,start/iso,end/iso,cpu,res
 
-## Printing help, field names, etc
+Summary of control options:
+
+  awk         space-separated fields with no spaces
+  csv         csv, values only
+  csvnamed    csv, with field tags eg duration=37
+  fixed       fixed-format
+  json        json
+  header      print a header line where sensible
+  nodefaults  do not print fields that have default (zero/blank) values
+  noheader    do not print a header line
+  tag:<value> print a column called "tag" last with <value> in every row
+
+Summary of print modifiers:
+
+  Timestamps are normally printed on the form "YYYY-MM-DD HH:MM" but can be
+  be modified by /sec and /iso to print seconds since epoch and RFC3339 dates:
+
+    Timestamp/sec -> 1732112701
+    Timestamp/iso -> 2024-11-20T14:25:01Z
+
+  Durations are normally printed on the form _d_h_m (days, hours, and minutes)
+  but can be modified by /sec to print second counts:
+
+    duration/sec  -> 12345
+
+## Available field names
 
 By running a command with `-fmt help`, extensive help is provided on all
-aspects of printing for the command.
+aspects of printing for the specific command.
+
+# time - How time is represented
+
+While timestamps are recorded in localtime at the cluster and are held in
+that localtime in the Jobanalyzer database, timestamps are converted to UTC
+when read from the database and all Jobanalyzer operations assume UTC time
+and all printing happens in UTC.
+
+As noted under `printing`, timestamps are normally printed on a form that
+does not include time zone information (ie, that the timezone is UTC).
+This can be confusing to consumers.  You have been warned.

--- a/code/sonalyze/sonalyze.go
+++ b/code/sonalyze/sonalyze.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime/pprof"
 	"regexp"
+	"runtime/pprof"
 	"strings"
 
 	"go-utils/status"
@@ -147,9 +147,9 @@ func sonalyze() error {
 var help string
 
 type helpText struct {
-	kwd string
+	kwd    string
 	header string
-	text string
+	text   string
 }
 
 var helpTopicRe = regexp.MustCompile(`^#\s+(\S+)\s+-\s*(.*)$`)

--- a/code/sonalyze/table/format.go
+++ b/code/sonalyze/table/format.go
@@ -572,6 +572,15 @@ type Formatter struct {
 	AliasOf string
 }
 
+func DefAlias(formatters map[string]Formatter, canonical, alias string) {
+	f, found := formatters[canonical]
+	if !found {
+		panic(fmt.Sprintf("Formatter not found: %s", canonical))
+	}
+	f.AliasOf = canonical
+	formatters[alias] = f
+}
+
 func StandardFormatHelp(
 	fmt string,
 	helpText string,
@@ -626,28 +635,7 @@ func PrintFormatHelp(out io.Writer, h *FormatHelp) {
 Defaults:
   %s
 
-Control:
-  awk         space-separated fields with no spaces
-  csv         csv, values only
-  csvnamed    csv, with field tags eg duration=37
-  fixed       fixed-format
-  json        json
-  header      print a header line where sensible
-  nodefaults  do not print fields that have default (zero/blank) values
-  noheader    do not print a header line
-  tag:<value> print a column called "tag" last with <value> in every row
-
-Modifiers:
-  Timestamps are normally printed on the form "YYYY-MM-DD HH:MM" but can be
-  be modified by /sec and /iso to print seconds since epoch and RFC3339 dates:
-
-    Timestamp/sec -> 1732112701
-    Timestamp/iso -> 2024-11-20T14:25:01Z
-
-  Durations are normally printed on the form _d_h_m (days, hours, and minutes)
-  but can be modified by /sec to print second counts:
-
-    duration/sec  -> 12345
+For control operations and data field modifiers, try 'sonalyze help printing'.
 
 `,
 			h.Defaults,

--- a/code/sonalyze/table/reflect.go
+++ b/code/sonalyze/table/reflect.go
@@ -100,9 +100,6 @@ func DefineTableFromTags(
 //
 // SynthesizedFormatSpecWithAttr uses an attribute to specify a simple formatting rule for a
 // synthesized output field computed from a real field.
-//
-// SynthesizedIndexedFormatSpecWithAttr uses an attribute to specify a simple formatting rule for a
-// synthesized output field computed from an element of a real array field.
 
 type SimpleFormatSpec struct {
 	Desc    string
@@ -139,14 +136,6 @@ type SynthesizedFormatSpecWithAttr struct {
 	Attr int
 }
 
-type SynthesizedIndexedFormatSpecWithAttr struct {
-	Desc     string
-	RealName string // array or slice
-	Index    int
-	Aliases  string
-	Attr     int
-}
-
 func DefineTableFromMap(
 	structTy reflect.Type,
 	fields map[string]any,
@@ -164,8 +153,6 @@ func DefineTableFromMap(
 		var realname string
 		switch s := v.(type) {
 		case SynthesizedFormatSpecWithAttr:
-			realname = s.RealName
-		case SynthesizedIndexedFormatSpecWithAttr:
 			realname = s.RealName
 		default:
 			continue
@@ -199,8 +186,6 @@ func DefineTableFromMap(
 					ok = true
 				case SynthesizedFormatSpecWithAttr:
 					panic(fmt.Sprintf("Struct field '%s' has synthesized spec", name))
-				case SynthesizedIndexedFormatSpecWithAttr:
-					panic(fmt.Sprintf("Struct field '%s' has synthesized indexed spec", name))
 				default:
 					panic("Invalid FormatSpec")
 				}
@@ -215,8 +200,6 @@ func DefineTableFromMap(
 					desc = info.Desc
 					attrs = info.Attr
 					ok = true
-				case SynthesizedIndexedFormatSpecWithAttr:
-					panic("NYI")
 				default:
 					panic("Invalid FormatSpec")
 				}

--- a/code/tests/relative/sonalyze/jobs-print.sh
+++ b/code/tests/relative/sonalyze/jobs-print.sh
@@ -28,3 +28,13 @@ for fmt in fixed csv csvnamed awk; do
     diff -b old-output.txt new-output.txt
     rm -f old-output.txt new-output.txt
 done
+
+# New names
+for fmt in csv awk; do
+    echo "Format old vs new"
+    $OLD_SONALYZE jobs -data-dir "$DATA_PATH" -config-file "$CONFIG" -f 2d -t 1d -fmt $fmt,noheader,jobm,job,user,duration,duration/sec,start,start/sec,end,end/sec,cpu-avg,cpu-peak,rcpu-avg,rcpu-peak,mem-avg,mem-peak,rmem-avg,rmem-peak,res-avg,res-peak,rres-avg,rres-peak,gpu-avg,gpu-peak,rgpu-avg,rgpu-peak,sgpu-avg,sgpu-peak,gpumem-avg,gpumem-peak,rgpumem-avg,rgpumem-peak,sgpumem-avg,sgpumem-peak,gpus,gpufail,cmd,host,now,now/sec,classification,cputime/sec,cputime,gputime/sec,gputime > old-output.txt
+    $NEW_SONALYZE jobs -data-dir "$DATA_PATH" -config-file "$CONFIG" -f 2d -t 1d -fmt $fmt,noheader,JobAndMark,Job,User,Duration,Duration/sec,Start,Start/sec,End,End/sec,CpuAvgPct,CpuPeakPct,RelativeCpuAvgPct,RelativeCpuPeakPct,MemAvgGB,MemPeakGB,RelativeMemAvgPct,RelativeMemPeakPct,ResidentMemAvgGB,ResidentMemPeakGB,RelativeResidentMemAvgPct,RelativeResidentMemPeakPct,GpuAvgPct,GpuPeakPct,RelativeGpuAvgPct,RelativeGpuPeakPct,OccupiedRelativeGpuAvgPct,OccupiedRelativeGpuPeakPct,GpuMemAvgGB,GpuMemPeakGB,RelativeGpuMemAvgPct,RelativeGpuMemPeakPct,OccupiedRelativeGpuMemAvgPct,OccupiedRelativeGpuMemPeakPct,Gpus,GpuFail,Cmd,Host,Now,Now/sec,Classification,CpuTime/sec,CpuTime,GpuTime/sec,GpuTime > new-output.txt
+    diff -b old-output.txt new-output.txt
+    rm -f old-output.txt new-output.txt
+done
+


### PR DESCRIPTION
This could use some better test cases, and of course this is just a halfway solution since we're eventually going to want to reflect on a table definition to generate query logic, but at least it introduces sane field names, and with this we have completed the transition to a new naming scheme and (mostly) reflected table logic.