### PR TITLE
For #756 - move SampleFilter out of db

### DIFF
--- a/code/sonalyze/application/local.go
+++ b/code/sonalyze/application/local.go
@@ -69,7 +69,7 @@ func buildRecordFilters(
 	command SampleAnalysisCommand,
 	cfg *config.ClusterConfig,
 	verbose bool,
-) (*Hosts, *db.SampleFilter, error) {
+) (*Hosts, *sonarlog.SampleFilter, error) {
 	args := command.SampleAnalysisFlags()
 
 	// Temporary limitation.
@@ -206,7 +206,7 @@ func buildRecordFilters(
 		minPid = 1000
 	}
 
-	var recordFilter = &db.SampleFilter{
+	var recordFilter = &sonarlog.SampleFilter{
 		IncludeUsers:    includeUsers,
 		IncludeHosts:    includeHosts.HostnameGlobber(),
 		IncludeJobs:     includeJobs,

--- a/code/sonalyze/cmd/command.go
+++ b/code/sonalyze/cmd/command.go
@@ -104,7 +104,7 @@ type SampleAnalysisCommand interface {
 		streams sonarlog.InputStreamSet,
 		bounds sonarlog.Timebounds,
 		hostGlobber *Hosts,
-		recordFilter *db.SampleFilter,
+		recordFilter *sonarlog.SampleFilter,
 	) error
 
 	// Retrieve configfile for those commands that allow it, otherwise "", or "" for absent

--- a/code/sonalyze/cmd/jobs/perform.go
+++ b/code/sonalyze/cmd/jobs/perform.go
@@ -111,7 +111,7 @@ func (jc *JobsCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds,
 	hostGlobber *Hosts,
-	_ *db.SampleFilter,
+	_ *sonarlog.SampleFilter,
 ) error {
 	if jc.Verbose {
 		Log.Infof("Streams constructed by postprocessing: %d", len(streams))

--- a/code/sonalyze/cmd/load/perform.go
+++ b/code/sonalyze/cmd/load/perform.go
@@ -27,7 +27,7 @@ func (lc *LoadCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds,
 	hostGlobber *Hosts,
-	_ *db.SampleFilter,
+	_ *sonarlog.SampleFilter,
 ) error {
 	fromIncl, toIncl := lc.InterpretFromToWithBounds(bounds)
 

--- a/code/sonalyze/cmd/metadata/metadata.go
+++ b/code/sonalyze/cmd/metadata/metadata.go
@@ -137,7 +137,7 @@ func (mdc *MetadataCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds, // for mdc.Bounds only
 	hostGlobber *Hosts,
-	_ *db.SampleFilter,
+	_ *sonarlog.SampleFilter,
 ) error {
 	if mdc.Times {
 		fmt.Fprintf(out, "From: %s\n", mdc.FromDate.Format(time.RFC3339))

--- a/code/sonalyze/cmd/nodes/nodes.go
+++ b/code/sonalyze/cmd/nodes/nodes.go
@@ -24,6 +24,7 @@ import (
 	"sonalyze/db"
 	"sonalyze/db/repr"
 	"sonalyze/db/special"
+	"sonalyze/sonarlog"
 	. "sonalyze/table"
 )
 
@@ -215,7 +216,7 @@ func (nc *NodeCommand) Perform(_ io.Reader, stdout, stderr io.Writer) error {
 func (nc *NodeCommand) buildRecordFilter(
 	includeHosts *Hosts,
 	verbose bool,
-) (*hostglob.HostGlobber, *db.SampleFilter, func(*repr.SysinfoData) bool, error) {
+) (*hostglob.HostGlobber, *sonarlog.SampleFilter, func(*repr.SysinfoData) bool, error) {
 	globber := includeHosts.HostnameGlobber()
 
 	haveFrom := nc.SourceArgs.HaveFrom
@@ -229,7 +230,7 @@ func (nc *NodeCommand) buildRecordFilter(
 		to = nc.SourceArgs.ToDate.Unix()
 	}
 
-	var recordFilter = &db.SampleFilter{
+	var recordFilter = &sonarlog.SampleFilter{
 		IncludeHosts: globber,
 		From:         from,
 		To:           to,

--- a/code/sonalyze/cmd/parse/parse.go
+++ b/code/sonalyze/cmd/parse/parse.go
@@ -160,7 +160,7 @@ func (pc *ParseCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds, // for pc.MergeByJob only
 	hostGlobber *Hosts,
-	recordFilter *db.SampleFilter,
+	recordFilter *sonarlog.SampleFilter,
 ) error {
 	var mergedSamples []*sonarlog.SampleStream
 	var samples sonarlog.SampleStream
@@ -179,7 +179,7 @@ func (pc *ParseCommand) Perform(
 		for _, records := range recordBlobs {
 			mapped = append(mapped, uslices.FilterMap(
 				records,
-				db.InstantiateSampleFilter(recordFilter),
+				sonarlog.InstantiateSampleFilter(recordFilter),
 				func(r *repr.Sample) sonarlog.Sample {
 					return sonarlog.Sample{Sample: r}
 				},

--- a/code/sonalyze/cmd/profile/perform.go
+++ b/code/sonalyze/cmd/profile/perform.go
@@ -28,7 +28,7 @@ func (pc *ProfileCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	_ sonarlog.Timebounds,
 	_ *Hosts,
-	_ *db.SampleFilter,
+	_ *sonarlog.SampleFilter,
 ) error {
 	jobId := pc.Job[0]
 

--- a/code/sonalyze/cmd/uptime/perform.go
+++ b/code/sonalyze/cmd/uptime/perform.go
@@ -71,7 +71,7 @@ func (uc *UptimeCommand) Perform(
 	streams sonarlog.InputStreamSet,
 	bounds sonarlog.Timebounds,
 	hostGlobber *Hosts,
-	_ *db.SampleFilter,
+	_ *sonarlog.SampleFilter,
 ) error {
 	samples := uslices.CatenateP(maps.Values(streams))
 	if uc.Verbose {

--- a/code/sonalyze/db/README.md
+++ b/code/sonalyze/db/README.md
@@ -1,5 +1,7 @@
 # The database
 
+(This is quite stale, and much of it should in any case be moved into doc.go.)
+
 ## Data model at a glance
 
 The database exposes six tables:

--- a/code/sonalyze/sonarlog/ingest.go
+++ b/code/sonalyze/sonarlog/ingest.go
@@ -28,7 +28,7 @@ func ReadSampleStreamsAndMaybeBounds(
 	c db.SampleDataProvider,
 	fromDate, toDate time.Time,
 	hostGlobber *Hosts,
-	recordFilter *db.SampleFilter,
+	recordFilter *SampleFilter,
 	wantBounds bool,
 	verbose bool,
 ) (

--- a/code/sonalyze/sonarlog/postprocess.go
+++ b/code/sonalyze/sonarlog/postprocess.go
@@ -14,7 +14,6 @@ import (
 	"go-utils/config"
 
 	. "sonalyze/common"
-	"sonalyze/db"
 	"sonalyze/db/repr"
 )
 
@@ -92,13 +91,13 @@ func standardSampleRectifier(xs []*repr.Sample, cfg *config.ClusterConfig) []*re
 
 func createInputStreams(
 	entryBlobs [][]*repr.Sample,
-	recordFilter *db.SampleFilter,
+	recordFilter *SampleFilter,
 	wantBounds bool,
 ) (InputStreamSet, Timebounds) {
 	streams := make(InputStreamSet)
 	bounds := make(Timebounds)
 
-	filterFunc := db.InstantiateSampleFilter(recordFilter)
+	filterFunc := InstantiateSampleFilter(recordFilter)
 
 	// Reconstruct the individual sample streams.  Each job with job id 0 gets its own stream, these
 	// must not be merged downstream (they get different stream IDs but the job IDs remain 0).

--- a/code/sonalyze/sonarlog/postprocess_test.go
+++ b/code/sonalyze/sonarlog/postprocess_test.go
@@ -90,7 +90,7 @@ func TestPostprocessLogCpuUtilPct(t *testing.T) {
 		[][]*repr.Sample{
 			entries,
 		},
-		&db.SampleFilter{
+		&SampleFilter{
 			ExcludeUsers: map[Ustr]bool{
 				StringToUstr("root"): true,
 			},

--- a/code/sonalyze/sonarlog/samplefilter.go
+++ b/code/sonalyze/sonarlog/samplefilter.go
@@ -1,6 +1,6 @@
 // Sample record filter.  This is performance-sensitive.
 
-package db
+package sonarlog
 
 import (
 	"go-utils/hostglob"
@@ -8,8 +8,10 @@ import (
 	"sonalyze/db/repr"
 )
 
-// The db.SampleFilter will be applied to individual records and must be true for records to be
-// included and false for all others.  It may be applied at any point in the ingestion pipeline.
+// The sonarlog.SampleFilter will be applied to individual records and must be true for records to
+// be included and false for all others.  It may in principle be applied at any point in the
+// ingestion pipeline but at this time it is applied after raw ingestion and is therefore not a part
+// of the database layer.
 //
 // The fields may all have zero values; however, if `To` is not a precise time then it should be set
 // to math.MaxInt64, as zero will mean zero here too.
@@ -32,8 +34,8 @@ type SampleFilter struct {
 // Construct an efficient filter function from the sample filter.
 //
 // This is a convenience function for external code that has a SampleFilter but needs to have a
-// function for filtering.  If the DB layer were to do any filtering by itself it would be under no
-// obligation to use this type of filter function.
+// function for filtering.  (If the DB layer were to do any filtering by itself it would be under no
+// obligation to use this type of filter function.)
 //
 // The recordFilter or its parts *MUST NOT* be modified by the caller subsequently, as parts of it
 // may be retained by the filter function and may be used on concurrent threads.  For all practical


### PR DESCRIPTION
Part of ongoing cleanup of the db layer, this code does not currently belong in the db package.