### PR TITLE
Fix #811 - Print sample run separator only when meaningful

### DIFF
--- a/code/sonalyze/cmd/parse/parse.go
+++ b/code/sonalyze/cmd/parse/parse.go
@@ -252,7 +252,9 @@ func (pc *ParseCommand) Perform(
 			if queryNeg != nil {
 				xs = slices.DeleteFunc(xs, queryNeg)
 			}
-			fmt.Fprintln(out, "*")
+			if pc.PrintOpts.Fixed || pc.PrintOpts.Separator {
+				fmt.Fprintln(out, "*")
+			}
 			FormatData(
 				out,
 				pc.PrintFields,

--- a/code/sonalyze/help.txt
+++ b/code/sonalyze/help.txt
@@ -155,6 +155,8 @@ Summary of control options:
   header      print a header line (not for json)
   nodefaults  do not print fields that have default (zero/blank) values
   noheader    do not print a header line
+  separator   for some commands, print a '*' separator line between natural
+              runs in the output
   tag:<value> print a column called "tag" last with <value> in every row
 
 Summary of print modifiers and formats:

--- a/code/sonalyze/table/format.go
+++ b/code/sonalyze/table/format.go
@@ -72,6 +72,7 @@ type FormatOptions struct {
 	Named      bool   // csvnamed explicitly requested
 	Header     bool   // true if nothing requested b/c fixed+header is default
 	NoDefaults bool   // if true and the string returned is "*skip*" and the mode is csv or json then print nothing
+	Separator  bool   // for some commands, print a separator between natural runs in the output
 }
 
 func (fo *FormatOptions) IsDefaultFormat() bool {
@@ -207,6 +208,7 @@ func StandardFormatOptions(others map[string]bool, def DefaultFormat) *FormatOpt
 	awk := others["awk"] && !csv && !json
 	fixed := others["fixed"] && !csv && !json && !awk
 	nodefaults := others["nodefaults"]
+	separator := others["separator"]
 	tag := ""
 	for x := range others {
 		if strings.HasPrefix(x, "tag:") {
@@ -235,6 +237,7 @@ func StandardFormatOptions(others map[string]bool, def DefaultFormat) *FormatOpt
 		Header:     header,
 		Tag:        tag,
 		Named:      csvnamed,
+		Separator:  separator,
 		NoDefaults: nodefaults,
 	}
 }
@@ -459,7 +462,7 @@ func formatJson(unbufOut io.Writer, fields []FieldSpec, opts *FormatOptions, col
 		fmt.Fprint(out, s.String())
 		rowSep = ","
 	}
-	fmt.Fprint(out, "]")
+	fmt.Fprintln(out, "]")
 }
 
 // TODO: IMPROVEME: Maybe handle control characters and other gunk better?

--- a/code/tests/sonalyze/load/json_output.sh
+++ b/code/tests/sonalyze/load/json_output.sh
@@ -1,9 +1,14 @@
 # Output shall be sorted by ascending host name and for each host, by ascending time For ML8, the
 # first cpu% is taken from the first record and the second is computed from delta time and delta
 # cputime_sec.
+#
+# The weird formatting is the result of some very old code interacting poorly with much newer code,
+# see comments in cmd/load/print.go.
 output=$($SONALYZE load --fmt=json,host,cpu --compact --none -- json_output.csv)
 CHECK json_output \
-      '[{"system":{"hostname":"ml4.hpc.uio.no","description":"Unknown","gpucards":"0"},"records":[{"host":"ml4.hpc.uio.no","cpu":"58"}]},{"system":{"hostname":"ml8.hpc.uio.no","description":"Unknown","gpucards":"0"},"records":[{"host":"ml8.hpc.uio.no","cpu":"18"},{"host":"ml8.hpc.uio.no","cpu":"231"}]}]' \
+      '[{"system":{"hostname":"ml4.hpc.uio.no","description":"Unknown","gpucards":"0"},"records":[{"host":"ml4.hpc.uio.no","cpu":"58"}]
+},{"system":{"hostname":"ml8.hpc.uio.no","description":"Unknown","gpucards":"0"},"records":[{"host":"ml8.hpc.uio.no","cpu":"18"},{"host":"ml8.hpc.uio.no","cpu":"231"}]
+}]' \
       "$output"
 
 output=$($SONALYZE load --fmt=json,host,cpu --compact --none -- empty_input.csv)

--- a/code/tests/sonarlog/merge.sh
+++ b/code/tests/sonarlog/merge.sh
@@ -5,7 +5,7 @@
 # Merge jobs within hosts but not across hosts.  This leaves the metadata untouched because it is
 # per-host, not per-stream or per-job.
 
-output=$($SONALYZE parse --merge-by-host-and-job --fmt=host,job,localtime -- merge.csv)
+output=$($SONALYZE parse --merge-by-host-and-job --fmt=separator,host,job,localtime -- merge.csv)
 CHECK parse_merge_by_host_and_job \
       '*
 ml1.hpc.uio.no,4052478,2023-09-13 22:00
@@ -60,7 +60,7 @@ CHECK metadata_merge_by_job \
 \"ml[1,8].hpc.uio.no\",2023-09-13 20:00,2023-09-14 02:25" \
       "$output"
 
-output=$($SONALYZE parse --merge-by-job --fmt=host,job,localtime,cputime_sec -- merge.csv)
+output=$($SONALYZE parse --merge-by-job --fmt=separator,host,job,localtime,cputime_sec -- merge.csv)
 CHECK parse_merge_by_job \
       "*
 ml8.hpc.uio.no,3744442,2023-09-13 22:00,1024

--- a/code/tests/sonarlog/regress_60_filter_dup_timestamps.sh
+++ b/code/tests/sonarlog/regress_60_filter_dup_timestamps.sh
@@ -1,7 +1,7 @@
 # The input file has three records in a single stream, the first two have the same timestamp but are
 # distinguishable, the second of the two should be filtered out when we clean.
 
-output=$($SONALYZE parse --clean --fmt=csv,job,cputime_sec -- regress_60_filter_dup_timestamps.csv)
+output=$($SONALYZE parse --clean --fmt=csv,separator,job,cputime_sec -- regress_60_filter_dup_timestamps.csv)
 CHECK parse_duplicate_timestamps '*
 1249151,314
 1249151,316' "$output"

--- a/code/tests/sonarlog/regress_63_filter_negative_utilization.sh
+++ b/code/tests/sonarlog/regress_63_filter_negative_utilization.sh
@@ -9,7 +9,7 @@
 # However there's bug 166: the filtering happens too late, so the utilization computed for this
 # record is (910-200)/(60*5)=2.367.
 
-output=$($SONALYZE parse --clean --fmt=csv,job,cputime_sec,cpu_util_pct -- regress_63_filter_negative_utilization.csv)
+output=$($SONALYZE parse --clean --fmt=csv,separator,job,cputime_sec,cpu_util_pct -- regress_63_filter_negative_utilization.csv)
 CHECK parse_duplicate_timestamps '*
 1249151,310,100
 1249151,910,1' "$output" 166


### PR DESCRIPTION
Also drive-by fix for JSON formatting: Terminate each object written with a newline.