### PR TITLE
For #616 - hide the config file inside the cluster abstraction

### DIFF
--- a/code/generate-table/parser/parser_test.go
+++ b/code/generate-table/parser/parser_test.go
@@ -23,7 +23,7 @@ func TestParser(t *testing.T) {
 		t.Fatal("table name")
 	}
 
-	if b.Fields.Type != "*config.NodeConfigRecord" {
+	if b.Fields.Type != "*repr.NodeSummary" {
 		t.Fatal("type name")
 	}
 	if len(b.Fields.Fields) != 8 {

--- a/code/generate-table/parser/testdata/test.go
+++ b/code/generate-table/parser/testdata/test.go
@@ -7,13 +7,13 @@ package main
 package nodes
 
 import (
-	"go-utils/config"
 	. "sonalyze/table"
+    "sonalyze/db/repr"
 )
 
 %%
 
-FIELDS *config.NodeConfigRecord
+FIELDS *repr.NodeSummary
 
  # Note the CrossNodeJobs field is a config-level attribute, it does not appear in the raw sysinfo
  # data, and so it is not included here.

--- a/code/sonalyze/application/application_test.go
+++ b/code/sonalyze/application/application_test.go
@@ -5,15 +5,39 @@ import (
 	"testing"
 
 	"sonalyze/cmd"
+	"sonalyze/db/special"
 )
+
+func testPrimitiveCommand(t *testing.T, command cmd.PrimitiveCommand, fields string, expect []string) {
+	err := command.Validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = cmd.OpenDataStoreFromCommand(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer special.CloseDataStore()
+	var stdout strings.Builder
+	err = command.Perform(nil, &stdout, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkTestOutput(t, stdout.String(), fields, expect)
+}
 
 func testSimpleCommand(t *testing.T, command cmd.SimpleCommand, fields string, expect []string) {
 	err := command.Validate()
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = cmd.OpenDataStoreFromCommand(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer special.CloseDataStore()
 	var stdout strings.Builder
-	err = command.Perform(nil, &stdout, nil)
+	err = command.Perform(cmd.NewMetaFromCommand(command), nil, &stdout, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,8 +49,13 @@ func testSampleAnalysisCommand(t *testing.T, command cmd.SampleAnalysisCommand, 
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = cmd.OpenDataStoreFromCommand(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer special.CloseDataStore()
 	var stdout, stderr strings.Builder
-	err = LocalSampleOperation(command, nil, &stdout, &stderr)
+	err = LocalSampleOperation(cmd.NewMetaFromCommand(command), command, nil, &stdout, &stderr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/code/sonalyze/application/cluster_format_test.go
+++ b/code/sonalyze/application/cluster_format_test.go
@@ -25,7 +25,7 @@ func testitCluster(t *testing.T, fields string) {
 		}
 	)
 	var cc clusters.ClusterCommand
-	cc.JobanalyzerDir = jobanalyzerDir
+	cc.DatabaseArgs.SetJobanalyzerDir(jobanalyzerDir, "")
 	cc.FormatArgs.Fmt = "csv,header," + fields
-	testSimpleCommand(t, &cc, fields, expect)
+	testPrimitiveCommand(t, &cc, fields, expect)
 }

--- a/code/sonalyze/application/config_format_test.go
+++ b/code/sonalyze/application/config_format_test.go
@@ -28,7 +28,7 @@ func testitConfigs(t *testing.T, fields string) {
 		}
 	)
 	var cc configs.ConfigCommand
-	cc.ConfigFileArgs.ConfigFilename = configFilename
+	cc.DatabaseArgs.SetConfigFile(configFilename, "cluster1")
 	cc.FormatArgs.Fmt = "csv,header," + fields
 	testSimpleCommand(t, &cc, fields, expect)
 }

--- a/code/sonalyze/application/metadata_format_test.go
+++ b/code/sonalyze/application/metadata_format_test.go
@@ -23,7 +23,7 @@ func testitMetadata(t *testing.T, fields string) {
 		}
 	)
 	var mc metadata.MetadataCommand
-	mc.SourceArgs.LogFiles = []string{"testdata/metadata_format/test.csv"}
+	mc.DatabaseArgs.SetLogFiles([]string{"testdata/metadata_format/test.csv"}, "logfiles.cluster")
 	mc.FormatArgs.Fmt = "csv,header," + fields
 	mc.Bounds = true
 	testSampleAnalysisCommand(t, &mc, fields, expect)

--- a/code/sonalyze/application/node_format_test.go
+++ b/code/sonalyze/application/node_format_test.go
@@ -27,7 +27,7 @@ func testitNode(t *testing.T, fields string) {
 		}
 	)
 	var nc nodes.NodeCommand
-	nc.SourceArgs.LogFiles = logFiles
+	nc.DatabaseArgs.SetLogFiles(logFiles, "logfiles.cluster")
 	nc.FormatArgs.Fmt = "csv,header," + fields
 	testSimpleCommand(t, &nc, fields, expect)
 }

--- a/code/sonalyze/cmd/cards/cards.go
+++ b/code/sonalyze/cmd/cards/cards.go
@@ -11,6 +11,7 @@ import (
 	"sonalyze/data/card"
 	"sonalyze/db"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -91,8 +92,8 @@ func (nc *CardCommand) ReifyForRemote(x *ArgReifier) error {
 	)
 }
 
-func (nc *CardCommand) Perform(_ io.Reader, stdout, stderr io.Writer) error {
-	theLog, err := db.OpenReadOnlyDB(nc.ConfigFile(), nc.DataDir, db.FileListCardData, nc.LogFiles)
+func (nc *CardCommand) Perform(meta special.ClusterMeta, _ io.Reader, stdout, stderr io.Writer) error {
+	theLog, err := db.OpenReadOnlyDB(meta, db.FileListCardData)
 	if err != nil {
 		return err
 	}

--- a/code/sonalyze/cmd/config.go
+++ b/code/sonalyze/cmd/config.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"go-utils/config"
 	. "sonalyze/common"
 	"sonalyze/data/sample"
+	"sonalyze/db/special"
 )
 
 // Standard method for cleaning an InputStreamSet relative to a config: the config must have a
@@ -14,27 +14,28 @@ import (
 //
 // Over time this may become more complicated, as the config becomes time-dependent.
 func EnsureConfigForInputStreams(
-	cfg *config.ClusterConfig,
+	meta special.ClusterMeta,
 	streams sample.InputStreamSet,
 	reason string,
 ) (sample.InputStreamSet, error) {
-	// Bail if there's no config data at all.
-	if cfg == nil {
-		return nil, fmt.Errorf("Configuration file required: %s", reason)
-	}
-
 	// Remove streams for which we have no config data.
 	bad := make(map[sample.InputStreamKey]bool)
 	for key, stream := range streams {
-		hn := (*stream)[0].Hostname.String()
-		if cfg.LookupHost(hn) == nil {
+		hn := (*stream)[0].Hostname
+		ts := (*stream)[0].Timestamp
+		if meta.LookupHostByTime(hn, ts) == nil {
 			bad[key] = true
-			Log.Infof("Warning: Missing host configuration for %s", hn)
+			Log.Infof("Warning: Missing host configuration for %s", hn.String())
 		}
 	}
 
 	for b := range bad {
 		delete(streams, b)
+	}
+
+	// Bail if there's no config data at all.
+	if len(streams) == 0 {
+		return nil, fmt.Errorf("All configuration data missing: %s", reason)
 	}
 
 	return streams, nil

--- a/code/sonalyze/cmd/configs/config-table.go
+++ b/code/sonalyze/cmd/configs/config-table.go
@@ -2,7 +2,7 @@
 
 package configs
 
-import "go-utils/config"
+import "sonalyze/db/repr"
 
 import (
 	"cmp"
@@ -22,51 +22,51 @@ var (
 )
 
 // MT: Constant after initialization; immutable
-var configFormatters = map[string]Formatter[*config.NodeConfigRecord]{
+var configFormatters = map[string]Formatter[*repr.NodeSummary]{
 	"Timestamp": {
-		Fmt: func(d *config.NodeConfigRecord, ctx PrintMods) string {
+		Fmt: func(d *repr.NodeSummary, ctx PrintMods) string {
 			return FormatString((d.Timestamp), ctx)
 		},
 		Help: "(string) Full ISO timestamp of when the reading was taken",
 	},
 	"Hostname": {
-		Fmt: func(d *config.NodeConfigRecord, ctx PrintMods) string {
+		Fmt: func(d *repr.NodeSummary, ctx PrintMods) string {
 			return FormatString((d.Hostname), ctx)
 		},
 		Help: "(string) Name that host is known by on the cluster",
 	},
 	"Description": {
-		Fmt: func(d *config.NodeConfigRecord, ctx PrintMods) string {
+		Fmt: func(d *repr.NodeSummary, ctx PrintMods) string {
 			return FormatString((d.Description), ctx)
 		},
 		Help: "(string) End-user description, not parseable",
 	},
 	"CpuCores": {
-		Fmt: func(d *config.NodeConfigRecord, ctx PrintMods) string {
+		Fmt: func(d *repr.NodeSummary, ctx PrintMods) string {
 			return FormatInt((d.CpuCores), ctx)
 		},
 		Help: "(int) Total number of cores x threads",
 	},
 	"MemGB": {
-		Fmt: func(d *config.NodeConfigRecord, ctx PrintMods) string {
+		Fmt: func(d *repr.NodeSummary, ctx PrintMods) string {
 			return FormatInt((d.MemGB), ctx)
 		},
 		Help: "(int) GB of installed main RAM",
 	},
 	"GpuCards": {
-		Fmt: func(d *config.NodeConfigRecord, ctx PrintMods) string {
+		Fmt: func(d *repr.NodeSummary, ctx PrintMods) string {
 			return FormatInt((d.GpuCards), ctx)
 		},
 		Help: "(int) Number of installed cards",
 	},
 	"GpuMemGB": {
-		Fmt: func(d *config.NodeConfigRecord, ctx PrintMods) string {
+		Fmt: func(d *repr.NodeSummary, ctx PrintMods) string {
 			return FormatInt((d.GpuMemGB), ctx)
 		},
 		Help: "(int) Total GPU memory across all cards",
 	},
 	"GpuMemPct": {
-		Fmt: func(d *config.NodeConfigRecord, ctx PrintMods) string {
+		Fmt: func(d *repr.NodeSummary, ctx PrintMods) string {
 			return FormatBool((d.GpuMemPct), ctx)
 		},
 		Help: "(bool) True if GPUs report accurate memory usage in percent",
@@ -85,49 +85,49 @@ func init() {
 }
 
 // MT: Constant after initialization; immutable
-var configPredicates = map[string]Predicate[*config.NodeConfigRecord]{
-	"Timestamp": Predicate[*config.NodeConfigRecord]{
-		Compare: func(d *config.NodeConfigRecord, v any) int {
+var configPredicates = map[string]Predicate[*repr.NodeSummary]{
+	"Timestamp": Predicate[*repr.NodeSummary]{
+		Compare: func(d *repr.NodeSummary, v any) int {
 			return cmp.Compare((d.Timestamp), v.(string))
 		},
 	},
-	"Hostname": Predicate[*config.NodeConfigRecord]{
-		Compare: func(d *config.NodeConfigRecord, v any) int {
+	"Hostname": Predicate[*repr.NodeSummary]{
+		Compare: func(d *repr.NodeSummary, v any) int {
 			return cmp.Compare((d.Hostname), v.(string))
 		},
 	},
-	"Description": Predicate[*config.NodeConfigRecord]{
-		Compare: func(d *config.NodeConfigRecord, v any) int {
+	"Description": Predicate[*repr.NodeSummary]{
+		Compare: func(d *repr.NodeSummary, v any) int {
 			return cmp.Compare((d.Description), v.(string))
 		},
 	},
-	"CpuCores": Predicate[*config.NodeConfigRecord]{
+	"CpuCores": Predicate[*repr.NodeSummary]{
 		Convert: CvtString2Int,
-		Compare: func(d *config.NodeConfigRecord, v any) int {
+		Compare: func(d *repr.NodeSummary, v any) int {
 			return cmp.Compare((d.CpuCores), v.(int))
 		},
 	},
-	"MemGB": Predicate[*config.NodeConfigRecord]{
+	"MemGB": Predicate[*repr.NodeSummary]{
 		Convert: CvtString2Int,
-		Compare: func(d *config.NodeConfigRecord, v any) int {
+		Compare: func(d *repr.NodeSummary, v any) int {
 			return cmp.Compare((d.MemGB), v.(int))
 		},
 	},
-	"GpuCards": Predicate[*config.NodeConfigRecord]{
+	"GpuCards": Predicate[*repr.NodeSummary]{
 		Convert: CvtString2Int,
-		Compare: func(d *config.NodeConfigRecord, v any) int {
+		Compare: func(d *repr.NodeSummary, v any) int {
 			return cmp.Compare((d.GpuCards), v.(int))
 		},
 	},
-	"GpuMemGB": Predicate[*config.NodeConfigRecord]{
+	"GpuMemGB": Predicate[*repr.NodeSummary]{
 		Convert: CvtString2Int,
-		Compare: func(d *config.NodeConfigRecord, v any) int {
+		Compare: func(d *repr.NodeSummary, v any) int {
 			return cmp.Compare((d.GpuMemGB), v.(int))
 		},
 	},
-	"GpuMemPct": Predicate[*config.NodeConfigRecord]{
+	"GpuMemPct": Predicate[*repr.NodeSummary]{
 		Convert: CvtString2Bool,
-		Compare: func(d *config.NodeConfigRecord, v any) int {
+		Compare: func(d *repr.NodeSummary, v any) int {
 			return CompareBool((d.GpuMemPct), v.(bool))
 		},
 	},

--- a/code/sonalyze/cmd/datastore.go
+++ b/code/sonalyze/cmd/datastore.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"errors"
+
+	"sonalyze/data/cluster"
+	"sonalyze/db"
+	"sonalyze/db/special"
+)
+
+func OpenDataStoreFromCommand(anyCmd Command) (err error) {
+	db.SetCacheSize(anyCmd.CacheSize())
+	if jd := anyCmd.JobanalyzerDir(); jd != "" {
+		err = special.OpenFullDataStore(jd)
+	} else if dd := anyCmd.DataDir(); dd != "" {
+		err = special.OpenDataStoreFromDataDir(dd, anyCmd.ConfigFile())
+	} else if rd := anyCmd.ReportDir(); rd != "" {
+		err = special.OpenDataStoreFromReportDir(rd, anyCmd.ConfigFile())
+	} else if fl := anyCmd.LogFiles(); len(fl) > 0 {
+		err = special.OpenDataStoreFromLogFiles(fl, anyCmd.ConfigFile())
+	} else if cf := anyCmd.ConfigFile(); cf != "" {
+		err = special.OpenDataStoreFromConfigFile(cf)
+	} else if anyCmd.Dataless() {
+	} else {
+		err = errors.New("No data source")
+	}
+	return
+}
+
+func NewMetaFromCommand(anyCmd Command) special.ClusterMeta {
+	c := special.LookupCluster(anyCmd.ClusterName())
+	if c == nil {
+		panic("Cluster name must be defined at this point, could not find '" + anyCmd.ClusterName() + "'")
+	}
+	return cluster.NewMetaFromCluster(c)
+}

--- a/code/sonalyze/cmd/gpus/gpus.go
+++ b/code/sonalyze/cmd/gpus/gpus.go
@@ -11,6 +11,7 @@ import (
 	. "sonalyze/common"
 	"sonalyze/data/gpusample"
 	"sonalyze/db"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -63,6 +64,7 @@ type GpuCommand struct /* implements AnalysisCommand */ {
 }
 
 var _ = AnalysisCommand((*GpuCommand)(nil))
+var _ = SimpleCommand((*GpuCommand)(nil))
 
 func (gc *GpuCommand) Add(fs *CLI) {
 	gc.HostAnalysisArgs.Add(fs)
@@ -96,8 +98,8 @@ type ReportLine struct {
 	*gpusample.PerGpuSample
 }
 
-func (gc *GpuCommand) Perform(_ io.Reader, stdout, stderr io.Writer) error {
-	theLog, err := db.OpenReadOnlyDB(gc.ConfigFile(), gc.DataDir, db.FileListGpuSampleData, gc.LogFiles)
+func (gc *GpuCommand) Perform(meta special.ClusterMeta, _ io.Reader, stdout, stderr io.Writer) error {
+	theLog, err := db.OpenReadOnlyDB(meta, db.FileListGpuSampleData)
 	if err != nil {
 		return err
 	}

--- a/code/sonalyze/cmd/load/print.go
+++ b/code/sonalyze/cmd/load/print.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"slices"
 
-	"go-utils/config"
+	"sonalyze/db/repr"
 	. "sonalyze/table"
 )
 
@@ -66,7 +66,7 @@ ELBAT*/
 
 type LoadReport struct {
 	hostname string
-	conf     *config.NodeConfigRecord // may be nil, beware
+	conf     *repr.NodeSummary // may be nil, beware
 	records  []*ReportRecord
 }
 

--- a/code/sonalyze/cmd/metadata/metadata.go
+++ b/code/sonalyze/cmd/metadata/metadata.go
@@ -8,12 +8,11 @@ import (
 	"slices"
 	"time"
 
-	"go-utils/config"
-
 	. "sonalyze/cmd"
 	. "sonalyze/common"
 	"sonalyze/data/sample"
 	"sonalyze/db"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -128,7 +127,7 @@ func (mdc *MetadataCommand) DefaultRecordFilters() (
 
 func (mdc *MetadataCommand) Perform(
 	out io.Writer,
-	_ *config.ClusterConfig,
+	_ special.ClusterMeta,
 	theDb db.SampleDataProvider,
 	filter sample.QueryFilter,
 	hosts *Hosts,

--- a/code/sonalyze/cmd/nodeprof/nodeprof.go
+++ b/code/sonalyze/cmd/nodeprof/nodeprof.go
@@ -11,6 +11,7 @@ import (
 	"sonalyze/data/nodesample"
 	"sonalyze/db"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -90,12 +91,10 @@ func (nc *NodeProfCommand) Validate() error {
 //
 // Processing
 
-func (nc *NodeProfCommand) Perform(_ io.Reader, stdout, stderr io.Writer) error {
+func (nc *NodeProfCommand) Perform(meta special.ClusterMeta, _ io.Reader, stdout, stderr io.Writer) error {
 	theLog, err := db.OpenReadOnlyDB(
-		nc.ConfigFile(),
-		nc.DataDir,
+		meta,
 		db.FileListNodeSampleData,
-		nc.LogFiles,
 	)
 	if err != nil {
 		return err

--- a/code/sonalyze/cmd/nodes/nodes.go
+++ b/code/sonalyze/cmd/nodes/nodes.go
@@ -12,6 +12,7 @@ import (
 	. "sonalyze/cmd"
 	"sonalyze/data/config"
 	"sonalyze/db"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -109,12 +110,10 @@ func (nc *NodeCommand) Validate() error {
 //
 // Processing
 
-func (nc *NodeCommand) Perform(_ io.Reader, stdout, stderr io.Writer) error {
+func (nc *NodeCommand) Perform(meta special.ClusterMeta, _ io.Reader, stdout, stderr io.Writer) error {
 	theLog, err := db.OpenReadOnlyDB(
-		nc.ConfigFile(),
-		nc.DataDir,
+		meta,
 		db.FileListNodeData|db.FileListCardData,
-		nc.LogFiles,
 	)
 	if err != nil {
 		return err

--- a/code/sonalyze/cmd/parse/parse.go
+++ b/code/sonalyze/cmd/parse/parse.go
@@ -7,13 +7,13 @@ import (
 	"io"
 	"slices"
 
-	"go-utils/config"
 	uslices "go-utils/slices"
 	. "sonalyze/cmd"
 	. "sonalyze/common"
 	"sonalyze/data/sample"
 	"sonalyze/db"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -164,7 +164,7 @@ func (pc *ParseCommand) ConfigFile() string {
 
 func (pc *ParseCommand) Perform(
 	out io.Writer,
-	_ *config.ClusterConfig,
+	_ special.ClusterMeta,
 	theDb db.SampleDataProvider,
 	filter sample.QueryFilter,
 	hosts *Hosts,

--- a/code/sonalyze/cmd/profile/perform.go
+++ b/code/sonalyze/cmd/profile/perform.go
@@ -7,18 +7,17 @@ import (
 	"math"
 	"slices"
 
-	"go-utils/config"
-
 	. "sonalyze/common"
 	"sonalyze/data/sample"
 	"sonalyze/db"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
 func (pc *ProfileCommand) Perform(
 	out io.Writer,
-	_ *config.ClusterConfig,
+	_ special.ClusterMeta,
 	theDb db.SampleDataProvider,
 	filter sample.QueryFilter,
 	hosts *Hosts,

--- a/code/sonalyze/cmd/sacct/perform.go
+++ b/code/sonalyze/cmd/sacct/perform.go
@@ -7,6 +7,7 @@ import (
 	. "sonalyze/common"
 	"sonalyze/data/slurmjob"
 	"sonalyze/db"
+	"sonalyze/db/special"
 )
 
 type sacctSummary struct {
@@ -16,8 +17,8 @@ type sacctSummary struct {
 	usedCpu      uint64
 }
 
-func (sc *SacctCommand) Perform(_ io.Reader, stdout, stderr io.Writer) error {
-	theLog, err := db.OpenReadOnlyDB(sc.ConfigFile(), sc.DataDir, db.FileListSlurmJobData, sc.LogFiles)
+func (sc *SacctCommand) Perform(meta special.ClusterMeta, _ io.Reader, stdout, stderr io.Writer) error {
+	theLog, err := db.OpenReadOnlyDB(meta, db.FileListSlurmJobData)
 	if err != nil {
 		return err
 	}

--- a/code/sonalyze/cmd/snodes/snodes.go
+++ b/code/sonalyze/cmd/snodes/snodes.go
@@ -10,6 +10,7 @@ import (
 	. "sonalyze/cmd"
 	"sonalyze/data/slurmnode"
 	"sonalyze/db"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -78,8 +79,8 @@ func (nc *SnodeCommand) ReifyForRemote(x *ArgReifier) error {
 	)
 }
 
-func (nc *SnodeCommand) Perform(_ io.Reader, stdout, stderr io.Writer) error {
-	theLog, err := db.OpenReadOnlyDB(nc.ConfigFile(), nc.DataDir, db.FileListSlurmNodeData, nc.LogFiles)
+func (nc *SnodeCommand) Perform(meta special.ClusterMeta, _ io.Reader, stdout, stderr io.Writer) error {
+	theLog, err := db.OpenReadOnlyDB(meta, db.FileListSlurmNodeData)
 	if err != nil {
 		return err
 	}

--- a/code/sonalyze/cmd/sparts/sparts.go
+++ b/code/sonalyze/cmd/sparts/sparts.go
@@ -10,6 +10,7 @@ import (
 	. "sonalyze/cmd"
 	"sonalyze/data/slurmpart"
 	"sonalyze/db"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -80,8 +81,8 @@ func (nc *SpartCommand) ReifyForRemote(x *ArgReifier) error {
 	)
 }
 
-func (nc *SpartCommand) Perform(_ io.Reader, stdout, stderr io.Writer) error {
-	theLog, err := db.OpenReadOnlyDB(nc.ConfigFile(), nc.DataDir, db.FileListSlurmPartitionData, nc.LogFiles)
+func (nc *SpartCommand) Perform(meta special.ClusterMeta, _ io.Reader, stdout, stderr io.Writer) error {
+	theLog, err := db.OpenReadOnlyDB(meta, db.FileListSlurmPartitionData)
 	if err != nil {
 		return err
 	}

--- a/code/sonalyze/cmd/top/top.go
+++ b/code/sonalyze/cmd/top/top.go
@@ -30,6 +30,7 @@ import (
 	. "sonalyze/common"
 	"sonalyze/data/cpusample"
 	"sonalyze/db"
+	"sonalyze/db/special"
 	. "sonalyze/table"
 )
 
@@ -38,6 +39,7 @@ type TopCommand struct /* implements AnalysisCommand */ {
 }
 
 var _ = AnalysisCommand((*TopCommand)(nil))
+var _ = SimpleCommand((*TopCommand)(nil))
 
 //go:embed summary.txt
 var summary string
@@ -63,8 +65,8 @@ func (tc *TopCommand) MaybeFormatHelp() *FormatHelp {
 	return nil
 }
 
-func (tc *TopCommand) Perform(stdin io.Reader, stdout, stderr io.Writer) error {
-	theLog, err := db.OpenReadOnlyDB(tc.ConfigFile(), tc.DataDir, db.FileListCpuSampleData, tc.LogFiles)
+func (tc *TopCommand) Perform(meta special.ClusterMeta, stdin io.Reader, stdout, stderr io.Writer) error {
+	theLog, err := db.OpenReadOnlyDB(meta, db.FileListCpuSampleData)
 	if err != nil {
 		return err
 	}

--- a/code/sonalyze/cmd/version/version.csv
+++ b/code/sonalyze/cmd/version/version.csv
@@ -1,3 +1,4 @@
+"0.13.0","IN DEVELOPMENT"
 "0.12.0","Move to Sonar v0.17.0-pre1 w/ Slurm *_resources fields.  Compute CrossNodeJobs, ignore config."
 "0.11.3","Bugfix: remove nonzero defaults for 'sacct' (#807)"
 "0.11.2","Bugfix: forward -last to remote"

--- a/code/sonalyze/cmd/version/version.go
+++ b/code/sonalyze/cmd/version/version.go
@@ -12,16 +12,15 @@ import (
 
 type VersionCommand struct {
 	// Add these to make this into a SimpleCommand
-	RemotingArgsNoCluster
+	DatabaseArgs
 	DevArgs
 	VerboseArgs
 }
 
-var _ = (SimpleCommand)((*VersionCommand)(nil))
-var _ = (RemotableCommand)((*VersionCommand)(nil))
+var _ = PrimitiveCommand((*VersionCommand)(nil))
 
 func (vc *VersionCommand) Add(fs *CLI) {
-	vc.RemotingArgsNoCluster.Add(fs)
+	vc.DatabaseArgs.Add(fs, DBArgOptions{NoDatabase: true})
 	vc.DevArgs.Add(fs)
 	vc.VerboseArgs.Add(fs)
 }
@@ -31,7 +30,7 @@ func (vc *VersionCommand) ReifyForRemote(x *ArgReifier) error {
 }
 
 func (vc *VersionCommand) Validate() error {
-	return vc.RemotingArgsNoCluster.Validate()
+	return vc.DatabaseArgs.Validate()
 }
 
 func (vc *VersionCommand) Summary(out io.Writer) {

--- a/code/sonalyze/data/cluster/meta.go
+++ b/code/sonalyze/data/cluster/meta.go
@@ -1,0 +1,63 @@
+package cluster
+
+import (
+	"slices"
+	_ "time"
+
+	. "sonalyze/common"
+	_ "sonalyze/data/config"
+	_ "sonalyze/db"
+	"sonalyze/db/repr"
+	"sonalyze/db/special"
+)
+
+type clusterMeta struct {
+	cluster        *special.ClusterEntry
+}
+
+func NewMetaFromCluster(cluster *special.ClusterEntry) special.ClusterMeta {
+	return &clusterMeta { cluster }
+}
+
+func (tm *clusterMeta) ClusterName() string {
+	return tm.cluster.Name
+}
+
+func (tm *clusterMeta) ExcludedUsers() []string {
+	return tm.cluster.ExcludeUser
+}
+
+func (tm *clusterMeta) LookupHostByTime(host Ustr, t int64) *repr.NodeSummary {
+	if tm.cluster.HaveConfig {
+		return tm.cluster.Config.LookupHost(host.String())
+	}
+	return nil
+}
+
+func (tm *clusterMeta) NodesDefinedInConfigIfAny() []*repr.NodeSummary {
+	if tm.cluster.HaveConfig {
+		return slices.Clone(tm.cluster.Config.Hosts())
+	}
+	return make([]*repr.NodeSummary, 0)
+}
+
+func (tm *clusterMeta) DataDir() string {
+	if tm.cluster.HaveDataDir {
+		return tm.cluster.DataDir
+	}
+	return ""
+}
+
+func (tm *clusterMeta) LogFiles() []string {
+	if tm.cluster.HaveLogFiles {
+		return tm.cluster.LogFiles
+	}
+	return nil
+}
+
+func (tm *clusterMeta) ReportDir() string {
+	if tm.cluster.HaveReportDir {
+		return tm.cluster.ReportDir
+	}
+	return ""
+}

--- a/code/sonalyze/data/config/config.go
+++ b/code/sonalyze/data/config/config.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"time"
 
-	uconfig "go-utils/config"
 	umaps "go-utils/maps"
 
 	"sonalyze/data/card"
@@ -17,7 +16,7 @@ import (
 )
 
 type NodeConfig struct {
-	uconfig.NodeConfigRecord
+	repr.NodeSummary
 	Distances string
 	TopoSVG   string
 	TopoText  string
@@ -104,7 +103,7 @@ func Query(theLog db.DataProvider, qa QueryArgs) ([]*NodeConfig, error) {
 			distances = fmt.Sprintf("%v", r.node.Distances)
 		}
 		records[i] = &NodeConfig{
-			NodeConfigRecord: uconfig.NodeConfigRecord{
+			NodeSummary: repr.NodeSummary{
 				Timestamp:   r.node.Time,
 				Hostname:    r.node.Node,
 				Description: desc,

--- a/code/sonalyze/data/sample/postprocess_test.go
+++ b/code/sonalyze/data/sample/postprocess_test.go
@@ -8,9 +8,11 @@ import (
 
 	"go-utils/config"
 	. "sonalyze/common"
+	"sonalyze/data/cluster"
 	"sonalyze/db"
 	"sonalyze/db/parse"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 )
 
 func TestRectifyGpuMem(t *testing.T) {
@@ -18,25 +20,28 @@ func TestRectifyGpuMem(t *testing.T) {
 	// should force the values in the record to something else.
 	memsize := 400
 	numcards := 1
-	cfg := config.NewClusterConfig(
-		2,
-		"Test",
-		"Test",
-		[]string{},
-		[]string{},
-		[]*config.NodeConfigRecord{
-			&config.NodeConfigRecord{
-				Timestamp: "2024-06-12T11:20:00+02.00",
-				Hostname:  "ml4.hpc.uio.no",
-				GpuMemPct: true,
-				GpuCards:  numcards,
-				GpuMemGB:  memsize,
+	special.OpenDataStoreFromConfig(
+		config.NewClusterConfig(
+			2,
+			"Test",
+			"Test",
+			[]string{},
+			[]string{},
+			[]*config.NodeConfigRecord{
+				&config.NodeConfigRecord{
+					Timestamp: "2024-06-12T11:20:00+02.00",
+					Hostname:  "ml4.hpc.uio.no",
+					GpuMemPct: true,
+					GpuCards:  numcards,
+					GpuMemGB:  memsize,
+				},
 			},
-		},
+		),
 	)
+	meta := cluster.NewMetaFromCluster(special.GetSingleCluster())
 	c, err := db.OpenFileListSampleDB(
+		meta,
 		[]string{"../../../tests/sonarlog/whitebox-logclean.csv"},
-		cfg,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/code/sonalyze/data/sample/samplefilter.go
+++ b/code/sonalyze/data/sample/samplefilter.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"os"
 
-	"go-utils/config"
 	"go-utils/hostglob"
 	umaps "go-utils/maps"
 	uslices "go-utils/slices"
@@ -16,6 +15,7 @@ import (
 	. "sonalyze/common"
 	"sonalyze/data/common"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 )
 
 // The sample.SampleFilter will be applied to individual records and must be true for records to be
@@ -335,7 +335,7 @@ type QueryFilter struct {
 }
 
 func BuildSampleFilter(
-	cfg *config.ClusterConfig,
+	meta special.ClusterMeta,
 	filter QueryFilter,
 	verbose bool,
 ) (
@@ -439,12 +439,10 @@ func BuildSampleFilter(
 		excludeCommands[StringToUstr("_heartbeat_")] = true
 	}
 
-	// System configuration additions, if available
+	// Cluster additions, if available
 
-	if cfg != nil {
-		for _, user := range cfg.ExcludeUser {
-			excludeUsers[StringToUstr(user)] = true
-		}
+	for _, user := range meta.ExcludedUsers() {
+		excludeUsers[StringToUstr(user)] = true
 	}
 
 	// Record filtering logic is the same for all commands.  The record filter can use only raw

--- a/code/sonalyze/db/dataprovider.go
+++ b/code/sonalyze/db/dataprovider.go
@@ -6,8 +6,6 @@ package db
 import (
 	"time"
 
-	"go-utils/config"
-
 	. "sonalyze/common"
 	"sonalyze/db/filedb"
 	"sonalyze/db/repr"
@@ -117,10 +115,8 @@ type CluzterDataProvider interface {
 	) (recordBlobs [][]*repr.CluzterNodes, softErrors int, err error)
 }
 
-// DataProvider provides all data types, and carries a cluster configuration with it.
+// DataProvider provides all data types.
 type DataProvider interface {
-	Config() *config.ClusterConfig
-
 	SampleDataProvider
 	SysinfoDataProvider
 	SacctDataProvider

--- a/code/sonalyze/db/datastore_test.go
+++ b/code/sonalyze/db/datastore_test.go
@@ -47,11 +47,11 @@ func tmpCopyTree(srcDir string) string {
 }
 
 func TestOpenClose(t *testing.T) {
-	pc, err := openPersistentCluster(theClusterDir, nil)
+	pc, err := openPersistentCluster(nil, theClusterDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	qc, err := openPersistentCluster(theClusterDir, nil)
+	qc, err := openPersistentCluster(nil, theClusterDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,18 +61,18 @@ func TestOpenClose(t *testing.T) {
 
 	// Closing should prevent more dirs from being opened
 	Close()
-	_, err = openPersistentCluster(theClusterDir, nil)
+	_, err = openPersistentCluster(nil, theClusterDir)
 	if err != errs.ClusterClosedErr {
 		t.Fatal("Should be closed")
 	}
 
 	// This should work even after Close() because file clusters are independent of the cluster
 	// store.
-	fs, err := OpenFileListSampleDB(theFiles, nil)
+	fs, err := OpenFileListSampleDB(nil, theFiles)
 	if err != nil {
 		t.Fatal(err)
 	}
-	gs, err := OpenFileListSampleDB(theFiles, nil)
+	gs, err := OpenFileListSampleDB(nil, theFiles)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestOpenClose(t *testing.T) {
 }
 
 func TestTransientSampleFilenames(t *testing.T) {
-	fs, err := OpenFileListSampleDB(theFiles, nil)
+	fs, err := OpenFileListSampleDB(nil, theFiles)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,7 +97,7 @@ func TestTransientSampleFilenames(t *testing.T) {
 }
 
 func TestTransientSampleRead(t *testing.T) {
-	fs, err := OpenFileListSampleDB(theFiles, nil)
+	fs, err := OpenFileListSampleDB(nil, theFiles)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +118,7 @@ func TestTransientSampleRead(t *testing.T) {
 }
 
 func TestPersistentSampleFilenames(t *testing.T) {
-	pc, err := openPersistentCluster(theClusterDir, nil)
+	pc, err := openPersistentCluster(nil, theClusterDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestPersistentSampleFilenames(t *testing.T) {
 }
 
 func TestPersistentSampleRead(t *testing.T) {
-	pc, err := openPersistentCluster(theClusterDir, nil)
+	pc, err := openPersistentCluster(nil, theClusterDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,7 +196,7 @@ func TestPersistentSampleRead(t *testing.T) {
 }
 
 func TestPersistentSysinfoRead(t *testing.T) {
-	pc, err := openPersistentCluster(theClusterDir, nil)
+	pc, err := openPersistentCluster(nil, theClusterDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +231,7 @@ func TestPersistentSampleAppend(t *testing.T) {
 	d := tmpCopyTree(theClusterDir)
 	defer os.RemoveAll(d)
 
-	pc, err := openPersistentCluster(d, nil)
+	pc, err := openPersistentCluster(nil, d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -270,7 +270,7 @@ func TestPersistentSysinfoAppend(t *testing.T) {
 	d := tmpCopyTree(theClusterDir)
 	defer os.RemoveAll(d)
 
-	pc, err := openPersistentCluster(d, nil)
+	pc, err := openPersistentCluster(nil, d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +381,7 @@ func TestPersistentSampleFlush(t *testing.T) {
 	d := tmpCopyTree(theClusterDir)
 	defer os.RemoveAll(d)
 
-	pc, err := openPersistentCluster(d, nil)
+	pc, err := openPersistentCluster(nil, d)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -481,7 +481,7 @@ func TestCaching(t *testing.T) {
 	Log.SetUnderlying(&ul)
 	Log.LowerLevelTo(status.LogLevelInfo)
 
-	pc, err := openPersistentCluster(d, nil)
+	pc, err := openPersistentCluster(nil, d)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/code/sonalyze/db/db.go
+++ b/code/sonalyze/db/db.go
@@ -7,30 +7,18 @@ import (
 
 // Utility to open a database from a set of parameters.  We must have dataDir xor logFiles.
 func OpenReadOnlyDB(
-	configFile string,
-	dataDir string,
+	meta special.ClusterMeta,
 	dataType FileListDataType,
-	logFiles []string,
 ) (
 	DataProvider,
 	error,
 ) {
-	cfg, err := special.MaybeGetConfig(configFile)
-	if err != nil {
-		return nil, err
-	}
 	var theLog DataProvider
-	if len(logFiles) > 0 {
-		// This does not work, probably a default value gets in the way?
-		// if dataDir != "" {
-		// 	return nil, fmt.Errorf("Can't have both dataDir and logFiles")
-		// }
-		theLog, err = OpenFileListDB(dataType, logFiles, cfg)
+	var err error
+	if len(meta.LogFiles()) > 0 {
+		theLog, err = OpenFileListDB(meta, dataType)
 	} else {
-		if dataDir == "" {
-			return nil, fmt.Errorf("Must have either dataDir or logFiles")
-		}
-		theLog, err = OpenPersistentDirectoryDB(dataDir, cfg)
+		theLog, err = OpenPersistentDirectoryDB(meta)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("Failed to open log store: %v", err)

--- a/code/sonalyze/db/filedb/cluzterfile.go
+++ b/code/sonalyze/db/filedb/cluzterfile.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"unsafe"
 
-	"go-utils/config"
 	. "sonalyze/common"
 	"sonalyze/db/parse"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 )
 
 type CluzterDataNeeded int
@@ -42,7 +42,7 @@ const (
 	CluzterFileKindNodeData
 )
 
-func NewCluzterFileMethods(_ *config.ClusterConfig, kind CluzterFileKind) *cluzterFileReadSyncMethods {
+func NewCluzterFileMethods(_ special.ClusterMeta, kind CluzterFileKind) *cluzterFileReadSyncMethods {
 	switch kind {
 	case CluzterFileKindAttributeData:
 		return &cluzterFileReadSyncMethods{DataNeedAttributesData}

--- a/code/sonalyze/db/filedb/filedb.go
+++ b/code/sonalyze/db/filedb/filedb.go
@@ -7,9 +7,9 @@ import (
 	"runtime"
 	"strings"
 
-	"go-utils/config"
 	. "sonalyze/common"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 )
 
 const (
@@ -21,15 +21,15 @@ const (
 var (
 	// This is applied to a set of samples newly read from a file, before caching.
 	// MT: Constant after initialization; immutable
-	SampleRectifier func([]*repr.Sample, *config.ClusterConfig) []*repr.Sample
+	SampleRectifier func([]*repr.Sample, special.ClusterMeta) []*repr.Sample
 
 	// This is applied to a set of load data newly read from a file, before caching.
 	// MT: Constant after initialization; immutable
-	CpuSamplesRectifier func([]*repr.CpuSamples, *config.ClusterConfig) []*repr.CpuSamples
+	CpuSamplesRectifier func([]*repr.CpuSamples, special.ClusterMeta) []*repr.CpuSamples
 
 	// This is applied to a set of GPU data newly read from a file, before caching.
 	// MT: Constant after initialization; immutable
-	GpuSamplesRectifier func([]*repr.GpuSamples, *config.ClusterConfig) []*repr.GpuSamples
+	GpuSamplesRectifier func([]*repr.GpuSamples, special.ClusterMeta) []*repr.GpuSamples
 )
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/code/sonalyze/db/filedb/sacctfile.go
+++ b/code/sonalyze/db/filedb/sacctfile.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"unsafe"
 
-	"go-utils/config"
 	. "sonalyze/common"
 	"sonalyze/db/parse"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 )
 
 type sacctPayloadType = []*repr.SacctInfo
@@ -19,7 +19,7 @@ type sacctFileReadSyncMethods struct {
 
 var _ = ReadSyncMethods((*sacctFileReadSyncMethods)(nil))
 
-func NewSacctFileMethods(_ *config.ClusterConfig) *sacctFileReadSyncMethods {
+func NewSacctFileMethods(_ special.ClusterMeta) *sacctFileReadSyncMethods {
 	return &sacctFileReadSyncMethods{}
 }
 

--- a/code/sonalyze/db/filedb/sysinfofile.go
+++ b/code/sonalyze/db/filedb/sysinfofile.go
@@ -4,10 +4,10 @@ import (
 	"io"
 	"unsafe"
 
-	"go-utils/config"
 	. "sonalyze/common"
 	"sonalyze/db/parse"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 )
 
 type SysinfoDataNeeded int
@@ -37,7 +37,7 @@ const (
 	SysinfoFileKindCardData
 )
 
-func NewSysinfoFileMethods(_ *config.ClusterConfig, kind SysinfoFileKind) *sysinfoFileReadSyncMethods {
+func NewSysinfoFileMethods(_ special.ClusterMeta, kind SysinfoFileKind) *sysinfoFileReadSyncMethods {
 	switch kind {
 	case SysinfoFileKindNodeData:
 		return &sysinfoFileReadSyncMethods{DataNeedNodeData}

--- a/code/sonalyze/db/filedb/transientdb.go
+++ b/code/sonalyze/db/filedb/transientdb.go
@@ -7,15 +7,15 @@ import (
 	"path"
 	"time"
 
-	"go-utils/config"
 	. "sonalyze/common"
 	"sonalyze/db/repr"
+	"sonalyze/db/special"
 )
 
 // TransientCluster is a transient cluster mixin that has only one type of files.
 type TransientCluster struct {
 	// MT: Immutable after initialization
-	cfg   *config.ClusterConfig
+	meta  special.ClusterMeta
 	files []*LogFile
 }
 
@@ -39,10 +39,6 @@ func processTransientFiles(fileNames []string, ty FileAttr) []*LogFile {
 	return files
 }
 
-func (tc *TransientCluster) Config() *config.ClusterConfig {
-	return tc.cfg
-}
-
 func (tc *TransientCluster) Filenames() ([]string, error) {
 	return Filenames(tc.files), nil
 }
@@ -58,17 +54,17 @@ type TransientSampleCluster struct /* implements SampleCluster */ {
 }
 
 func NewTransientSampleCluster(
-	fileNames []string,
+	meta special.ClusterMeta,
 	ty FileAttr,
-	cfg *config.ClusterConfig,
+	fileNames []string,
 ) *TransientSampleCluster {
 	return &TransientSampleCluster{
-		samplesMethods:     NewSampleFileMethods(cfg, SampleFileKindSample),
-		nodeSamplesMethods: NewSampleFileMethods(cfg, SampleFileKindNodeSample),
-		loadDataMethods:    NewSampleFileMethods(cfg, SampleFileKindCpuSamples),
-		gpuDataMethods:     NewSampleFileMethods(cfg, SampleFileKindGpuSamples),
+		samplesMethods:     NewSampleFileMethods(meta, SampleFileKindSample),
+		nodeSamplesMethods: NewSampleFileMethods(meta, SampleFileKindNodeSample),
+		loadDataMethods:    NewSampleFileMethods(meta, SampleFileKindCpuSamples),
+		gpuDataMethods:     NewSampleFileMethods(meta, SampleFileKindGpuSamples),
 		TransientCluster: TransientCluster{
-			cfg:   cfg,
+			meta:  meta,
 			files: processTransientFiles(fileNames, ty),
 		},
 	}
@@ -121,14 +117,14 @@ type TransientSacctCluster struct /* implements SacctCluster */ {
 }
 
 func NewTransientSacctCluster(
-	fileNames []string,
+	meta special.ClusterMeta,
 	ty FileAttr,
-	cfg *config.ClusterConfig,
+	fileNames []string,
 ) *TransientSacctCluster {
 	return &TransientSacctCluster{
-		methods: NewSacctFileMethods(cfg),
+		methods: NewSacctFileMethods(meta),
 		TransientCluster: TransientCluster{
-			cfg:   cfg,
+			meta:  meta,
 			files: processTransientFiles(fileNames, ty),
 		},
 	}
@@ -154,15 +150,15 @@ type TransientSysinfoCluster struct /* implements SysinfoCluster */ {
 }
 
 func NewTransientSysinfoCluster(
-	fileNames []string,
+	meta special.ClusterMeta,
 	ty FileAttr,
-	cfg *config.ClusterConfig,
+	fileNames []string,
 ) *TransientSysinfoCluster {
 	return &TransientSysinfoCluster{
-		nodeDataMethods: NewSysinfoFileMethods(cfg, SysinfoFileKindNodeData),
-		cardDataMethods: NewSysinfoFileMethods(cfg, SysinfoFileKindCardData),
+		nodeDataMethods: NewSysinfoFileMethods(meta, SysinfoFileKindNodeData),
+		cardDataMethods: NewSysinfoFileMethods(meta, SysinfoFileKindCardData),
 		TransientCluster: TransientCluster{
-			cfg:   cfg,
+			meta:  meta,
 			files: processTransientFiles(fileNames, ty),
 		},
 	}
@@ -202,16 +198,16 @@ type TransientCluzterCluster struct /* implements CluzterCluster */ {
 }
 
 func NewTransientCluzterCluster(
-	fileNames []string,
+	meta special.ClusterMeta,
 	ty FileAttr,
-	cfg *config.ClusterConfig,
+	fileNames []string,
 ) *TransientCluzterCluster {
 	return &TransientCluzterCluster{
-		attributeMethods: NewCluzterFileMethods(cfg, CluzterFileKindAttributeData),
-		partitionMethods: NewCluzterFileMethods(cfg, CluzterFileKindPartitionData),
-		nodeMethods:      NewCluzterFileMethods(cfg, CluzterFileKindNodeData),
+		attributeMethods: NewCluzterFileMethods(meta, CluzterFileKindAttributeData),
+		partitionMethods: NewCluzterFileMethods(meta, CluzterFileKindPartitionData),
+		nodeMethods:      NewCluzterFileMethods(meta, CluzterFileKindNodeData),
 		TransientCluster: TransientCluster{
-			cfg:   cfg,
+			meta:  meta,
 			files: processTransientFiles(fileNames, ty),
 		},
 	}

--- a/code/sonalyze/db/repr/node.go
+++ b/code/sonalyze/db/repr/node.go
@@ -4,7 +4,11 @@ package repr
 
 import (
 	"unsafe"
+
+	"go-utils/config"
 )
+
+type NodeSummary = config.NodeConfigRecord
 
 // SysinfoNodeData is basically a view on newfmt.SysinfoAttributes where
 // newfmt=github.com/NordicHPC/sonar/util/formats/newfmt.  The reason it is a separate view is that

--- a/code/sonalyze/db/special/cluster_test.go
+++ b/code/sonalyze/db/special/cluster_test.go
@@ -7,16 +7,16 @@ import (
 )
 
 func TestCluster(t *testing.T) {
-	clusters, aliases, err := ReadClusterData("../filedb/testdata")
+	err := OpenFullDataStore("../filedb/testdata")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(clusters) != 2 {
-		t.Fatal("Cluster length", clusters)
+	if len(AllClusters()) != 2 {
+		t.Fatal("Cluster length", AllClusters())
 	}
 
-	c1, found := clusters["cluster1.uio.no"]
-	if !found {
+	c1 := LookupCluster("cluster1.uio.no")
+	if c1 == nil {
 		t.Fatal("cluster1")
 	}
 	if c1.Name != "cluster1.uio.no" {
@@ -26,8 +26,8 @@ func TestCluster(t *testing.T) {
 		t.Fatal("cluster1 desc", c1)
 	}
 
-	c2, found := clusters["cluster2.uio.no"]
-	if !found {
+	c2 := LookupCluster("cluster2.uio.no")
+	if c2 == nil {
 		t.Fatal("cluster2")
 	}
 	if c2.Name != "cluster2.uio.no" {
@@ -37,12 +37,12 @@ func TestCluster(t *testing.T) {
 		t.Fatal("cluster2 desc", c2)
 	}
 
-	r1 := aliases.Resolve("c1")
+	r1 := ResolveClusterName("c1")
 	if r1 != "cluster1.uio.no" {
 		t.Fatal("c1", r1)
 	}
 
-	r2 := aliases.Resolve("c2")
+	r2 := ResolveClusterName("c2")
 	if r2 != "cluster2.uio.no" {
 		t.Fatal("c2", r2)
 	}

--- a/code/sonalyze/db/special/config.go
+++ b/code/sonalyze/db/special/config.go
@@ -17,14 +17,6 @@ var (
 	configCache     = make(map[string]*config.ClusterConfig)
 )
 
-// Read the config file if the file name is not empty.
-func MaybeGetConfig(configFileName string) (*config.ClusterConfig, error) {
-	if configFileName == "" {
-		return nil, nil
-	}
-	return ReadConfigData(configFileName)
-}
-
 // ReadConfigData reads or returns the cached config, which is a shared object that will not be
 // modified subsequently and must not be modified by the caller.  (Cache invalidation will never
 // invalidate the object either, but subsequent calls may return a different object.)
@@ -42,13 +34,4 @@ func ReadConfigData(configFileName string) (*config.ClusterConfig, error) {
 	}
 	configCache[configFileName] = cfg
 	return cfg, nil
-}
-
-// Invalidate all cached config data from all files.  Data that have been returned earlier continues
-// to be live, but ReadConfigData will re-read.
-func InvalidateConfigCache() {
-	configCacheLock.Lock()
-	defer configCacheLock.Unlock()
-
-	clear(configCache)
 }

--- a/code/sonalyze/db/special/meta.go
+++ b/code/sonalyze/db/special/meta.go
@@ -1,0 +1,43 @@
+package special
+
+import (
+	. "sonalyze/common"
+	"sonalyze/db/repr"
+)
+
+// The ClusterMeta is largely a per-command object representing an implementation-near view on the
+// cluster for that command.  It needs to be fairly cheap and it will tend to wrap other data (eg,
+// the methods of implementing objects may call into the database layer, and may reference
+// more-persistent cluster and configuration data).  It is part of a manually managed "cluster
+// table" that does not quite exist yet, but also an API to dynamic cluster configuration data.
+// It's a bit of a hodgepodge and will evolve over time.
+type ClusterMeta interface {
+	// Return the name of the cluster.  This is assumed to be time-unvarying.
+	ClusterName() string
+
+	// The set of excluded users is time-dependent but we're going to ignore that for now.
+	ExcludedUsers() []string
+
+	// A fresh list of nodes present in a static config if we have a static config, otherwise an
+	// empty slice.
+	//
+	// NOTE: This API will likely go away; in the future, configs will not provide node data.
+	NodesDefinedInConfigIfAny() []*repr.NodeSummary
+
+	// This can be nil.  We want the latest host information at or before the given time, which is
+	// seconds since Unix epoch.  If the database has to be queried, the query window into the past
+	// may be limited to 14 days.  The result is not necessarily stable, it may change if new data
+	// come in, but will never revert to older data.  New data that replace a prior non-nil result
+	// may or may not be honored in a timely manner.  A static cluster configuration, should it
+	// exist, will be consulted only if the information can't be found in the database.
+	LookupHostByTime(host Ustr, time int64) *repr.NodeSummary
+
+	// Return a list of logfiles iff we have them, otherwise nil
+	LogFiles() []string
+
+	// Return a data directory either from -data-dir or computed from -jobanalyzer-dir, otherwise ""
+	DataDir() string
+
+	// Return a data directory either from -report-dir or computed from -jobanalyzer-dir, otherwise ""
+	ReportDir() string
+}

--- a/code/tests/config/config-file.sh
+++ b/code/tests/config/config-file.sh
@@ -21,7 +21,7 @@ CHECK_ERR nocpu_host_config $exitcode "$output" "(Field 'cpu_cores' must be pres
 # Can't open file
 output=$($SONALYZE jobs --user - --fmt=csv,job,rcpu --config-file nonexistent-host-config.json -- dummy-data.csv 2>&1)
 exitcode=$?
-CHECK_ERR nocpu_host_config $exitcode "$output" "[Nn]o such file or directory"
+CHECK_ERR nocpu_host_config $exitcode "$output" "([Nn]o such file or directory)|(Bad -config-file file nonexistent-host-config)"
 
 # Bad field value for "cpu_cores"
 output=$($SONALYZE jobs --user - --fmt=csv,job,rcpu --config-file badcpu-host-config.json -- dummy-data.csv 2>&1)

--- a/code/tests/sonarlog/parse.sh
+++ b/code/tests/sonarlog/parse.sh
@@ -37,10 +37,10 @@ output=$($SONALYZE parse --fmt=job,gpu_status -- parse_gpufail.csv | sort)
 CHECK parse_gpufail "1269178,1
 1269179,0" "$output"
 
-# Input file does not exist.  The Go and Rust versions have different capitalization of the error message.
+# Input file does not exist.
 output=$($SONALYZE parse -- no-such-file.csv 2>&1)
 exitcode=$?
-CHECK_ERR parse_no_file $exitcode "$output" "[Nn]o such file or directory"
+CHECK_ERR parse_no_file $exitcode "$output" "No such input file: no-such-file.csv"
 
 # This file has four records, the second has a timestamp that is out of range and the fourth has a
 # timestamp that is malformed.  We should be left with two.


### PR DESCRIPTION
This is fairly massive but most of it is plumbing and cleanup:

- plumb a 'special.ClusterMeta' object through most things.  It provides an API to the underlying special.ClusterEntry object, which has all the information needed to manage the cluster's data
- hide the config file and other data sources (file lists, data directories, report directories) inside the implementation of the ClusterEntry
- get rid of all mentions of the database representation except in the db layer
- regularize the command line switches for the data store and remove the insane distributed code for this
- create an abstraction for "opening a data store" that serves all current use cases and combinations of command line switches
- lift the opening of the data store very high up in the call tree (which we can do now), There Can Be Only One

This is not quite done - there's still a bit missing that avoids the config file altogether when we have a data directory that can serve those data.
