### PR TITLE
No bug - cluster command not implemented remotely

### DIFF
--- a/code/sonalyze/application/remote.go
+++ b/code/sonalyze/application/remote.go
@@ -118,6 +118,8 @@ func RemoteOperation(rCmd Command, verb string, stdin io.Reader, stdout, stderr 
 		curlArgs = append(curlArgs, "--get")
 	case SimpleCommand:
 		curlArgs = append(curlArgs, "--get")
+	case PrimitiveCommand:
+		curlArgs = append(curlArgs, "--get")
 	default:
 		panic("Unimplemented")
 	}


### PR DESCRIPTION
This was just an oversight in the client-side remoting logic: the cluster command is a PrimitiveCommand and was not handled in the type switch and would trigger a panic.
