### PR TITLE
Fix #845 - Allow -database-uri without -jobanalyzer-dir

### DIFF
--- a/code/sonalyze/cmd/args.go
+++ b/code/sonalyze/cmd/args.go
@@ -73,7 +73,7 @@ func (va *VerboseArgs) VerboseFlag() bool {
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //
-// The data source.  This is fairly elaborate to cover multiple use cases.
+// The data source(s).  This is fairly elaborate to cover multiple use cases.
 //
 // The data source can be "remote" or local.  If it is remote, then the command is forwarded to the
 // remote server and executed on a local data store there, ie, a "remote" source is just a REST
@@ -96,6 +96,10 @@ func (va *VerboseArgs) VerboseFlag() bool {
 // *all* data are found within that directory at known locations.  This precludes -data-dir,
 // -config-file, -report-dir, and a file list.  However, it allows a -database-uri argument that
 // specifies that the data store is to be found at the URI, using well-known mechanisms for access.
+//
+// Otherwise, if a -database-uri argument is present (without -jobanalyzer-dir) then it specifies
+// that the data store is to be found at the URI.  This precludes -data-dir and -config-file;
+// clusters are inferred (imperfectly) from the database.
 //
 // Otherwise, if -data-dir is present then that is a directory for a single cluster's sample,
 // sysinfo, and slurm data store and the -config-file argument may provide cluster configuration
@@ -284,15 +288,13 @@ func (db *DatabaseArgs) Validate() error {
 	//  - -remote
 	//  - -cluster without other args that indicate local execution
 	localData := db.jobanalyzerDir != "" || db.dataDir != "" || db.reportDir != "" ||
-		db.configFile != "" || len(db.logFiles) > 0
+		db.configFile != "" || db.databaseUri != "" || len(db.logFiles) > 0 ||
+		HasDefault(DataSourceDataDir) || HasDefault(DataSourceDatabaseUri)
 	if db.remoteHost != "" || (db.clusterName != "" && !localData) {
 		db.remoting = true
 	}
 
 	// Basic validation of mutually exclusive situations
-	if db.jobanalyzerDir == "" && db.databaseUri != "" {
-		return errors.New("-database-uri requires -jobanalyzer-dir")
-	}
 	switch {
 	case db.remoting:
 		if db.jobanalyzerDir != "" {
@@ -326,6 +328,16 @@ func (db *DatabaseArgs) Validate() error {
 		if len(db.logFiles) > 0 {
 			return errors.New("A -jobanalyzer-dir precludes a file list")
 		}
+	case db.databaseUri != "":
+		if db.dataDir != "" {
+			return errors.New("A -database-uri precludes a -data-dir")
+		}
+		if db.configFile != "" {
+			return errors.New("A -database-uri precludes a -config-file")
+		}
+		if len(db.logFiles) > 0 {
+			return errors.New("A -database-uri precludes a file list")
+		}
 	case db.dataDir != "":
 		if db.databaseUri != "" {
 			return errors.New("A -data-dir precludes a -database-uri")
@@ -357,13 +369,15 @@ func (db *DatabaseArgs) Validate() error {
 		}
 	}
 
-	// Apply defaults for the remote data source
 	if db.remoting {
 		ApplyDefault(&db.remoteHost, DataSourceRemote)
 		if os.Getenv("SONALYZE_AUTH") == "" {
 			ApplyDefault(&db.authFile, DataSourceAuthFile)
 		}
 		ApplyDefault(&db.clusterName, DataSourceCluster)
+	} else {
+		ApplyDefault(&db.dataDir, DataSourceDataDir)
+		ApplyDefault(&db.databaseUri, DataSourceDatabaseUri)
 	}
 
 	var e1, e2, e3, e4, e5, e6, e7 error

--- a/code/sonalyze/cmd/datastore.go
+++ b/code/sonalyze/cmd/datastore.go
@@ -12,6 +12,8 @@ func OpenDataStoreFromCommand(anyCmd Command) (err error) {
 	db.SetCacheSize(anyCmd.CacheSize())
 	if jd := anyCmd.JobanalyzerDir(); jd != "" {
 		err = db.OpenFullDataStore(jd, anyCmd.DatabaseURI())
+	} else if dburi := anyCmd.DatabaseURI(); dburi != "" {
+		err = db.OpenFullDataStore("", dburi)
 	} else if dd := anyCmd.DataDir(); dd != "" {
 		err = db.OpenDataStoreFromDataDir(dd, anyCmd.ConfigFile())
 	} else if rd := anyCmd.ReportDir(); rd != "" {

--- a/code/sonalyze/common/inifile.go
+++ b/code/sonalyze/common/inifile.go
@@ -10,15 +10,16 @@ import (
 
 // MT: Constant after initialization
 var (
-	p                  = ini.NewParser()
-	store              *ini.Store
-	dataSource         = p.AddSection("data-source")
-	DataSourceRemote   = dataSource.AddString("remote")
-	DataSourceAuthFile = dataSource.AddString("auth-file")
-	DataSourceCluster  = dataSource.AddString("cluster")
-	DataSourceDataDir  = dataSource.AddString("data-dir")
-	DataSourceFrom     = dataSource.AddString("from")
-	DataSourceTo       = dataSource.AddString("to")
+	p                     = ini.NewParser()
+	store                 *ini.Store
+	dataSource            = p.AddSection("data-source")
+	DataSourceRemote      = dataSource.AddString("remote")
+	DataSourceAuthFile    = dataSource.AddString("auth-file")
+	DataSourceCluster     = dataSource.AddString("cluster")
+	DataSourceDataDir     = dataSource.AddString("data-dir")
+	DataSourceDatabaseUri = dataSource.AddString("database-uri")
+	DataSourceFrom        = dataSource.AddString("from")
+	DataSourceTo          = dataSource.AddString("to")
 )
 
 func init() {

--- a/code/sonalyze/db/db.go
+++ b/code/sonalyze/db/db.go
@@ -78,15 +78,17 @@ func OpenFullDataStore(jobanalyzerDir, databaseURI string) error {
 
 	// Add aliases to known clusters.  The aliases file is optional, but if something with that name
 	// is there it is an error to fail to open it.
-	aliasesFile := filesys.MakeClusterAliasesPath(jobanalyzerDir)
-	if info, bad := os.Stat(aliasesFile); bad == nil {
-		if info.Mode()&fs.ModeType != 0 {
-			return errors.New("Cluster alias file is not a regular file")
-		}
-		var err error
-		aliases, err = alias.ReadAliases(aliasesFile)
-		if err != nil {
-			return err
+	if jobanalyzerDir != "" {
+		aliasesFile := filesys.MakeClusterAliasesPath(jobanalyzerDir)
+		if info, bad := os.Stat(aliasesFile); bad == nil {
+			if info.Mode()&fs.ModeType != 0 {
+				return errors.New("Cluster alias file is not a regular file")
+			}
+			var err error
+			aliases, err = alias.ReadAliases(aliasesFile)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if aliases != nil {
@@ -102,7 +104,7 @@ func OpenFullDataStore(jobanalyzerDir, databaseURI string) error {
 		cfg, err := special.ReadConfigData(filesys.MakeConfigFilePath(jobanalyzerDir, c))
 		if err != nil {
 			// Arguably we could remove it, but this code will change anyway.
-			v.Description = "No configuration found"
+			v.Description = "Cluster: " + c
 			continue
 		}
 		v.Description = cfg.Description

--- a/code/sonalyze/db/timescaledb.go
+++ b/code/sonalyze/db/timescaledb.go
@@ -109,7 +109,10 @@ func OpenDatabaseURI(databaseURI string) (*databaseConnection, error) {
 }
 
 func (cdb *databaseConnection) EnumerateClusters() ([]string, error) {
-	rows, err := cdb.Query(context.Background(), "SELECT cluster FROM cluster_attributes")
+	rows, err := cdb.Query(
+		context.Background(),
+		"SELECT cluster FROM cluster_attributes GROUP BY cluster",
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +121,7 @@ func (cdb *databaseConnection) EnumerateClusters() ([]string, error) {
 		return nil, err
 	}
 	// Workaround for https://github.com/2maz/slurm-monitor/issues/17 which we can remove soon:
-	// cluster names can be duplicated.
+	// cluster names can be duplicated.  Also, the GROUP BY should take care of it.
 	uniqueClusters := make(map[string]bool)
 	for _, c := range rawClusters {
 		uniqueClusters[c] = true
@@ -537,16 +540,16 @@ func (cdb *connectedDB) ReadSacctData(
 	verbose bool,
 ) (recordBlobs [][]*repr.SacctInfo, softErrors int, err error) {
 	var (
-		account, allocTRES, cluster, distribution, jobStep, jobName         string
-		jobState, partition, reservation, userName                          string
-		nodes                                                               []string
-		aveCPU, aveDiskRead, aveDiskWrite, aveRSS, aveVMSize, elapsedRaw    pgtype.Int8
-		hetJobId, jobId, maxRSS, maxVMSize, minCPU, priority, suspendTime   pgtype.Int8
-		systemCPU, timeLimit, userCPU, arrayJobId                           pgtype.Int8
-		hetJobOffset, requestedCpus, requestedMemoryPerNode                 int
-		requestedNodeCount                                                  int
-		endTime, startTime                                                  pgtype.Timestamptz
-		submitTime, timestamp                                               time.Time
+		account, allocTRES, cluster, distribution, jobStep, jobName       string
+		jobState, partition, reservation, userName                        string
+		nodes                                                             []string
+		aveCPU, aveDiskRead, aveDiskWrite, aveRSS, aveVMSize, elapsedRaw  pgtype.Int8
+		hetJobId, jobId, maxRSS, maxVMSize, minCPU, priority, suspendTime pgtype.Int8
+		systemCPU, timeLimit, userCPU, arrayJobId                         pgtype.Int8
+		hetJobOffset, requestedCpus, requestedMemoryPerNode               int
+		requestedNodeCount                                                int
+		endTime, startTime                                                pgtype.Timestamptz
+		submitTime, timestamp                                             time.Time
 	)
 
 	// Nullable, ignore NULL and translate to empty string or zero


### PR DESCRIPTION
Technically we could infer cluster aliases from cluster names but I'm going to file that as a followup, I don't want to get into it right now.