### PR TITLE
fix cron startup flags for sonalyze daemon

### DIFF
--- a/production/jobanalyzer-server/start-sonalyzed.sh
+++ b/production/jobanalyzer-server/start-sonalyzed.sh
@@ -15,8 +15,10 @@ rm -f $pidfile
 $sonalyzed_dir/sonalyze daemon \
     -cache 12G \
     -jobanalyzer-dir $sonalyzed_dir \
-    -port $sonalyzed_port \
-    -match-user-and-cluster \
+    -v0 \
+    -v1 \
+    -insert \
+    -rest-api :$sonalyzed_port \
     -analysis-auth $sonalyzed_analysis_auth_file \
     -upload-auth $sonalyzed_upload_auth_file &
 sonalyzed_pid=$!


### PR DESCRIPTION
The cron startup script in `production/jobanalyzer-server/start-sonalyzed.sh` used outdated `sonalyze daemon` flags.

Changes:
- use `-rest-api` instead of `-port`
- enable `-v0` , `-v1` ,  and `-insert`
- remove unsupported `-match-user-and-cluster`

Closes #924 